### PR TITLE
Fix GitHub Pages custom domain configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="Reviewstr - Location-Based Reviews on Nostr">
     <meta property="og:description" content="Share your experiences and discover amazing places on the Nostr network. Upload photos, rate locations, and earn Lightning tips.">
-    <meta http-equiv="content-security-policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self' https:; font-src 'self'; base-uri 'self'; manifest-src 'self'; connect-src 'self' blob: https: wss:; img-src 'self' data: blob: https:; media-src 'self' https:">
+    <meta http-equiv="content-security-policy" content="default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src 'self' https:; font-src 'self'; base-uri 'self'; manifest-src 'self'; connect-src 'self' blob: https: wss:; img-src 'self' data: blob: https: *; media-src 'self' https: *">
     <link rel="manifest" href="/manifest.webmanifest">
   </head>
   <body>

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -41,7 +41,7 @@ import NotFound from "./pages/NotFound";
 
 export function AppRouter() {
   return (
-    <BrowserRouter basename="/traveltelly/">
+    <BrowserRouter>
       <ScrollToTop />
       <Routes>
         <Route path="/" element={<Index />} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
-  base: "/traveltelly/",
+  base: "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
- Remove base path from vite.config.ts for custom domain
- Remove basename from BrowserRouter for custom domain
- Update CSP policy to allow external resources
- This should fix traveltelly.com not loading