### PR TITLE
Fix Stripe.js blocked by CSP on every page

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     <meta property="twitter:image" content="https://www.traveltelly.com/og-image.jpg?v=2026">
     <meta property="twitter:site" content="@traveltelly">
     <meta property="twitter:creator" content="@traveltelly">
-    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://www.googletagmanager.com https://*.google-analytics.com; style-src 'self' 'unsafe-inline' https://unpkg.com; style-src-elem 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' data:; frame-src 'self' https:; base-uri 'self'; manifest-src 'self'; worker-src 'self' blob:; child-src 'self' blob:; connect-src 'self' blob: https: wss:; img-src 'self' data: blob: https: *; media-src 'self' blob: https: *">
+    <meta http-equiv="content-security-policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://www.googletagmanager.com https://*.google-analytics.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://unpkg.com; style-src-elem 'self' 'unsafe-inline' https://unpkg.com; font-src 'self' data:; frame-src 'self' https:; base-uri 'self'; manifest-src 'self'; worker-src 'self' blob:; child-src 'self' blob:; connect-src 'self' blob: https: wss:; img-src 'self' data: blob: https: *; media-src 'self' blob: https: *">
     <!-- Leaflet CSS from CDN (loaded here to avoid ESM bundler issues with image assets) -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
     <link rel="manifest" href="/manifest.webmanifest">


### PR DESCRIPTION
## Summary

Fixes the console error `Failed to load Stripe.js` (CSP violation) that fires on **every page** of the site.

`@stripe/stripe-js` v7.5.0 eagerly preloads `https://js.stripe.com/basil/stripe.js` at module scope when the bundle loads. The site's CSP `script-src` in `index.html` did not allow `js.stripe.com`, so Chrome blocks the script at page load and the error fires on every route (single ~2.7 MB bundle).

## Change

Add `https://js.stripe.com` to the `script-src` directive in `index.html`:

```diff
-script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://www.googletagmanager.com https://*.google-analytics.com;
+script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://www.googletagmanager.com https://*.google-analytics.com https://js.stripe.com;
```

Verified live in headless Chrome by the originating report.

## Impact

Clears the console error on the homepage and every route. Unblocks the Marketplace card checkout (`StripePayment` → `GuestCheckout`) when a `pk_` key is present. Without this, card payments can never initialize if a key is ever baked into the build or stored in localStorage.
