### PR TITLE
Auto-list telly-map pin photos on /marketplace

### DIFF
--- a/public/telly-map.html
+++ b/public/telly-map.html
@@ -1642,6 +1642,35 @@ $('pubbtn').onclick = async () => {
      nostrId = signed.id;
      if(acks > 0) toast('✅ Published to ' + acks + ' relay' + (acks>1?'s':'') + '!', 4000);
      else         toast('⚠️ Signed but no relay accepted it — pin saved locally.', 5000);
+
+     /* 2b ── auto-list the pin photo on /marketplace (kind 30402, $0.99) so every pin is also for sale */
+     if(imageUrl){
+      try{
+       const mktTags = [
+        ['d',        'product_' + Date.now().toString(36) + Math.random().toString(36).slice(2,9)],
+        ['title',    title],
+        ['summary',  (place || title).slice(0,200)],
+        ['price',    '0.99', 'USD'],
+        ['t',        'photos'],
+        ['category', 'landmarks'],
+        ['status',   'active'],
+        ['published_at', String(Math.floor(Date.now()/1000))],
+        ['image',    imageUrl],
+       ];
+       if(place) mktTags.push(['location', place]);
+       mktTags.push(['g', gh]);
+       const mktEv = {
+        kind: 30402,
+        created_at: Math.floor(Date.now()/1000),
+        content: place || title,
+        tags: mktTags,
+       };
+       const mktSigned = await nostrSign(mktEv);
+       await nostrPublishEvent(mktSigned);
+      }catch(mktErr){
+       console.warn('Marketplace auto-list failed for pin:', mktErr.message || mktErr);
+      }
+     }
     }catch(e){
      toast('⚠️ Nostr publish failed: ' + (e.message||e) + '. Pin saved locally.', 6000);
     }


### PR DESCRIPTION
## Root cause

The marketplace auto-list feature (PR #12) only published companion kind 30402 listings from the **Create Review form** (CreateReviewForm.tsx). But the actual world-map pin tool — public/telly-map.html, the "+ Add pins" flow users actually use to drop photo pins on the map — had no marketplace code, so pins posted there never appeared for sale on /marketplace.

This is why new pins weren't showing up: they were published as kind 34879 reviews with images, but no companion 30402 listing was ever created.

## Fix

Now, when telly-map.html publishes a pin with a photo (kind 34879), it also publishes a companion NIP-99 classified listing (kind 30402) at **$0.99 USD**, carrying the same title, summary/place, image URL, location tag, and geohash — signed by the same uploader, to the same relays /marketplace queries (ditto/dreamith/primal). Pins without a photo are untouched.

Behavior now matches the CreateReviewForm auto-list exactly.

Validation: the edited inline script block parses clean (esbuild); failures are pre-existing top-level JSON blobs unchanged from baseline.