### PR TITLE
Add Marketplace Editor link to Admin Panel quick actions

### DIFF
--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -20,7 +20,7 @@ import { AdminBadgeManager } from '@/components/AdminBadgeManager';
 import { BlossomDashboard } from '@/components/BlossomDashboard';
 import { useInitializeTestCustomer } from '@/hooks/useInitializeTestCustomer';
 import { nip19 } from 'nostr-tools';
-import { Shield, ArrowLeft, Camera, MessageSquare, Settings, Tag, FileImage, Coffee, MapPin, Upload, BookOpen, Smartphone, Clock, BarChart3, Crown, Users, Mail, Sparkles, UsersRound, HardDrive, ScanSearch, Zap, Medal } from 'lucide-react';
+import { Shield, ArrowLeft, Camera, MessageSquare, Settings, Tag, FileImage, Coffee, MapPin, Upload, BookOpen, Smartphone, Clock, BarChart3, Crown, Users, Mail, Sparkles, UsersRound, HardDrive, ScanSearch, Zap, Medal, Store } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 export default function AdminPanel() {
@@ -186,6 +186,12 @@ export default function AdminPanel() {
                   <Button variant="default" className="bg-gradient-to-r from-yellow-500 to-orange-500 hover:from-yellow-600 hover:to-orange-600">
                     <Zap className="w-4 h-4 mr-2" />
                     Payments
+                  </Button>
+                </Link>
+                <Link to="/admin/marketplace">
+                  <Button variant="default" className="bg-gradient-to-r from-pink-600 to-rose-600 hover:from-pink-700 hover:to-rose-700">
+                    <Store className="w-4 h-4 mr-2" />
+                    Marketplace Editor
                   </Button>
                 </Link>
                 <Link to="/admin#review-permissions">


### PR DESCRIPTION
## Problem

The Marketplace Editor at `/admin/marketplace` (which hosts the **Backfill Pins → Marketplace** panel) was only reachable via the Bin Media Workspace page — the Admin Panel at `/admin` had **no link to it**, so it was effectively undiscoverable.

Reported in TravelTelly.com Updates channel (thread 75927b3090e3b1f2392c2f61ccb5c802d04daeb8923f06dca2ebccc9cb21b37b): "don't see marketplace editor at /admin".

## Change

Add a **Marketplace Editor** quick action button on the Admin Panel (next to Payments) linking to `/admin/marketplace`.

## Validation

- `tsc --noEmit` passes
- `vitest` passes
- `vite build` passes