### PR TITLE
Speed up /marketplace; add Latest strip + Place-based collections; fix map photo thumbs

### DIFF
--- a/src/components/MarketplaceBinSection.tsx
+++ b/src/components/MarketplaceBinSection.tsx
@@ -134,7 +134,7 @@ function useBinProducts(bin: MarketplaceBin, authorizedUploaders: string[]) {
       const filter: NostrFilter = {
         kinds: [30402],
         authors: authorizedUploaders,
-        limit: 12,
+        limit: 40,
       };
 
       // Apply relay-side filter where possible
@@ -164,6 +164,19 @@ function useBinProducts(bin: MarketplaceBin, authorizedUploaders: string[]) {
               p.geoFolder?.startsWith(bin.filterValue),
           );
           break;
+        case 'place': {
+          // Case-insensitive keyword matched against the sale listing's place
+          // name / GPS-driven location text (e.g. "Hong Kong", "Barcelona").
+          const kw = bin.filterValue.trim().toLowerCase();
+          products = products.filter(
+            (p) =>
+              (p.location?.toLowerCase() ?? '').includes(kw) ||
+              (p.geoFolder?.toLowerCase() ?? '').includes(kw) ||
+              (p.description?.toLowerCase() ?? '').includes(kw) ||
+              (p.title?.toLowerCase() ?? '').includes(kw),
+          );
+          break;
+        }
         case 'featured': {
           const ids = bin.filterValue.split(',').map((s) => s.trim()).filter(Boolean);
           products = products.filter((p) => ids.includes(p.id));

--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
+import { getGridThumbUrl } from '@/lib/imageUtils';
 
 interface OptimizedImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   src: string;
@@ -13,54 +14,6 @@ interface OptimizedImageProps extends React.ImgHTMLAttributes<HTMLImageElement> 
   aspectRatio?: string;
   /** Use thumbnail optimization (smaller size, lower quality for cards/feeds) */
   thumbnail?: boolean;
-}
-
-/**
- * Generates a thumbnail URL from a Blossom server image URL
- * Blossom supports automatic resizing via query parameters
- */
-function getThumbnailUrl(url: string, width: number = 600, quality: number = 75): string {
-  try {
-    // Check if it's a Blossom server URL (nostr.build, satellite.earth, etc.)
-    const urlObj = new URL(url);
-    
-    // For nostr.build and image.nostr.build, use their specific thumbnail format
-    if (urlObj.hostname.includes('nostr.build')) {
-      // For image.nostr.build or nostr.build, just add width parameter
-      if (!urlObj.searchParams.has('w')) {
-        urlObj.searchParams.set('w', width.toString());
-      }
-      // Don't add quality param for nostr.build - they handle it automatically
-      return urlObj.toString();
-    }
-    
-    // For blossom.primal.net, DON'T add resize params - they don't support it reliably
-    // Just return the original URL
-    if (urlObj.hostname.includes('blossom.primal.net') || urlObj.hostname.includes('primal.net')) {
-      return url;
-    }
-    
-    // For other Blossom servers that support resizing
-    const blossomDomains = [
-      'satellite.earth', 
-      'void.cat', 
-      'nostrcheck.me',
-    ];
-    const isBlossomServer = blossomDomains.some(domain => urlObj.hostname.includes(domain));
-    
-    if (isBlossomServer) {
-      urlObj.search = '';
-      urlObj.searchParams.set('w', width.toString());
-      urlObj.searchParams.set('q', quality.toString());
-      return urlObj.toString();
-    }
-    
-    // For non-Blossom URLs, return original
-    return url;
-  } catch {
-    // If URL parsing fails, return original
-    return url;
-  }
 }
 
 /**
@@ -78,9 +31,15 @@ function getBlurPlaceholderUrl(url: string): string {
       return urlObj.toString();
     }
     
-    // For primal.net, skip blur - just return original
+    // For primal.net, build a tiny Weserv-proxied WebP so the blur placeholder
+    // is a small fast stub instead of a full-size original.
     if (urlObj.hostname.includes('primal.net')) {
-      return url;
+      const u = new URL('https://images.weserv.nl/');
+      u.searchParams.set('url', url);
+      u.searchParams.set('w', '24');
+      u.searchParams.set('q', '20');
+      u.searchParams.set('output', 'webp');
+      return u.toString();
     }
     
     // For other Blossom servers that support resizing
@@ -128,7 +87,7 @@ export function OptimizedImage({
   const width = thumbnail ? (isMobile ? 150 : 400) : 800;
   // Mobile: 50% quality (smallest files), Desktop: 75%
   const quality = thumbnail ? (isMobile ? 50 : 75) : 80;
-  const thumbnailUrl = getThumbnailUrl(src, width, quality);
+  const thumbnailUrl = getGridThumbUrl(src, width, quality);
   const blurUrl = blurUp ? getBlurPlaceholderUrl(src) : null;
 
   // Debug logging for first few images

--- a/src/hooks/useMarketplaceBins.ts
+++ b/src/hooks/useMarketplaceBins.ts
@@ -24,12 +24,13 @@ export interface MarketplaceBin {
   emoji: string;         // e.g. "🐘" (kept for backward compat, no longer used in UI)
   coverImage?: string;  // optional cover photo URL (legacy)
   thumbnailImage?: string; // image URL picked from collection media items
-  /** Filter mode: category = content category tag, tag = t-tag, geo = continent/country, featured = hand-picked ids */
-  filterType: 'category' | 'tag' | 'geo' | 'featured';
+  /** Filter mode: category = content category tag, tag = t-tag, geo = continent/country, place = location keyword, featured = hand-picked ids */
+  filterType: 'category' | 'tag' | 'geo' | 'place' | 'featured';
   /** Value that drives the filter:
    *  - category → e.g. "Animals"
    *  - tag       → e.g. "wildlife"
    *  - geo       → e.g. "Europe/Netherlands" or just "Europe"
+   *  - place     → case-insensitive keyword matched against the location/GPS place name, e.g. "Hong Kong"
    *  - featured  → comma-separated product d-tag ids
    */
   filterValue: string;

--- a/src/hooks/useMarketplaceProducts.ts
+++ b/src/hooks/useMarketplaceProducts.ts
@@ -17,6 +17,15 @@ const MARKETPLACE_FALLBACK_RELAYS = [
 ];
 
 /**
+ * The admin-product fallback fetch is expensive (fans out to 3 public relays
+ * and can transfer ~1000 events each). Deduplicate it across ALL marketplace
+ * hooks and repeat visits with a short TTL cache, so /marketplace only pays the
+ * cost once every few minutes instead of on every mount/refetch.
+ */
+const FALLBACK_CACHE_TTL_MS = 5 * 60 * 1000;
+let fallbackCache: { at: number; events: NostrEvent[] } | null = null;
+
+/**
  * Query kind 30402 events by the admin pubkey directly from a set of relays,
  * bypassing the NPool. Returns raw events or [] on failure.
  */
@@ -24,7 +33,7 @@ async function queryAdminProductsFromRelays(signal: AbortSignal): Promise<NostrE
   const filter: NostrFilter = {
     kinds: [30402],
     authors: [ADMIN_HEX],
-    limit: 2000,
+    limit: 500,
   };
 
   const results = await Promise.allSettled(
@@ -49,6 +58,19 @@ async function queryAdminProductsFromRelays(signal: AbortSignal): Promise<NostrE
     }
   }
   return Array.from(seen.values());
+}
+
+/** Cached wrapper around queryAdminProductsFromRelays. */
+async function getAdminProductsCached(signal: AbortSignal): Promise<NostrEvent[]> {
+  const now = Date.now();
+  if (fallbackCache && now - fallbackCache.at < FALLBACK_CACHE_TTL_MS) {
+    return fallbackCache.events;
+  }
+  const events = await queryAdminProductsFromRelays(signal);
+  if (events.length > 0) {
+    fallbackCache = { at: now, events };
+  }
+  return events;
 }
 
 export interface MarketplaceProduct {
@@ -236,7 +258,7 @@ export function useMarketplaceProducts(options: UseMarketplaceProductsOptions = 
   return useQuery({
     queryKey: ['marketplace-products', JSON.stringify(options), Array.from(authorizedUploaders || [])],
     queryFn: async (c) => {
-      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(25000)]);
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(10000)]);
 
       const authorizedAuthors = Array.from(authorizedUploaders || []);
       // Always include admin even if permission grants haven't loaded yet
@@ -256,7 +278,7 @@ export function useMarketplaceProducts(options: UseMarketplaceProductsOptions = 
       const [poolEvents, fallbackEvents] = await Promise.allSettled([
         nostr.query([filter], { signal }),
         // For admin-only queries, also hit the fallback relays directly
-        authors.includes(ADMIN_HEX) ? queryAdminProductsFromRelays(signal) : Promise.resolve([]),
+        authors.includes(ADMIN_HEX) ? getAdminProductsCached(signal) : Promise.resolve([]),
       ]);
 
       const rawEvents: NostrEvent[] = [
@@ -311,7 +333,6 @@ export function useMarketplaceProducts(options: UseMarketplaceProductsOptions = 
       return products;
     },
     staleTime: 30_000,
-    refetchInterval: 60_000,
   });
 }
 
@@ -330,7 +351,7 @@ export function useInfiniteMarketplaceProducts(options: UseMarketplaceProductsOp
   return useInfiniteQuery({
     queryKey: ['marketplace-products-infinite', JSON.stringify(options), Array.from(authorizedUploaders || [])],
     queryFn: async ({ pageParam, signal }) => {
-      const abortSignal = AbortSignal.any([signal, AbortSignal.timeout(15000)]);
+      const abortSignal = AbortSignal.any([signal, AbortSignal.timeout(10000)]);
 
       const authorizedAuthors = Array.from(authorizedUploaders || []);
       if (!authorizedAuthors.includes(ADMIN_HEX)) {
@@ -352,7 +373,7 @@ export function useInfiniteMarketplaceProducts(options: UseMarketplaceProductsOp
       const [poolResult, fallbackResult] = await Promise.allSettled([
         nostr.query([filter], { signal: abortSignal }),
         (!until && authors.includes(ADMIN_HEX))
-          ? queryAdminProductsFromRelays(abortSignal)
+          ? getAdminProductsCached(abortSignal)
           : Promise.resolve([]),
       ]);
 

--- a/src/pages/AdminMarketplace.tsx
+++ b/src/pages/AdminMarketplace.tsx
@@ -48,6 +48,7 @@ import {
   Image as ImageIcon,
   Tag,
   Globe,
+  MapPin,
   Star,
   LayoutGrid,
   ExternalLink,
@@ -177,6 +178,15 @@ function FilterValueInput({
       />
     );
   }
+  if (filterType === 'place') {
+    return (
+      <Input
+        placeholder="e.g. Hong Kong, Barcelona, Paris"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
   // featured
   return (
     <Textarea
@@ -193,6 +203,7 @@ function filterTypeIcon(ft: MarketplaceBin['filterType']) {
     case 'category': return <Tag className="w-3.5 h-3.5" />;
     case 'tag': return <Tag className="w-3.5 h-3.5" />;
     case 'geo': return <Globe className="w-3.5 h-3.5" />;
+    case 'place': return <MapPin className="w-3.5 h-3.5" />;
     case 'featured': return <Star className="w-3.5 h-3.5" />;
   }
 }
@@ -202,6 +213,7 @@ function filterTypeLabel(ft: MarketplaceBin['filterType']) {
     case 'category': return 'Category';
     case 'tag': return 'Tag';
     case 'geo': return 'Geography';
+    case 'place': return 'Place';
     case 'featured': return 'Featured';
   }
 }
@@ -363,6 +375,13 @@ function useBinMediaImages(filterType: MarketplaceBin['filterType'], filterValue
           const geoFolder = event.tags.find(([n]) => n === 'geo_folder')?.[1];
           if (continent !== filterValue && country !== filterValue && !geoFolder?.startsWith(filterValue)) continue;
         }
+        if (filterType === 'place') {
+          const kw = filterValue.trim().toLowerCase();
+          const loc = event.tags.find(([n]) => n === 'location')?.[1]?.toLowerCase() ?? '';
+          const geoFolder = event.tags.find(([n]) => n === 'geo_folder')?.[1]?.toLowerCase() ?? '';
+          const text = `${loc} ${geoFolder} ${event.content}`.toLowerCase();
+          if (!text.includes(kw)) continue;
+        }
         if (filterType === 'featured') {
           const ids = filterValue.split(',').map((s) => s.trim());
           const d = event.tags.find(([n]) => n === 'd')?.[1];
@@ -465,7 +484,7 @@ function BinEditDialog({
               How should the marketplace pick photos for this bin?
             </p>
             <div className="grid grid-cols-2 gap-2 mt-1">
-              {(['category', 'tag', 'geo', 'featured'] as const).map((ft) => (
+              {(['category', 'tag', 'geo', 'place', 'featured'] as const).map((ft) => (
                 <button
                   key={ft}
                   type="button"
@@ -489,6 +508,7 @@ function BinEditDialog({
               {form.filterType === 'category' && 'Content category'}
               {form.filterType === 'tag' && 'Tag (t-tag value)'}
               {form.filterType === 'geo' && 'Continent / Region'}
+              {form.filterType === 'place' && 'Place keyword (e.g. Hong Kong)'}
               {form.filterType === 'featured' && 'Featured product IDs'}
               <span className="text-red-500"> *</span>
             </Label>
@@ -503,6 +523,7 @@ function BinEditDialog({
               {form.filterType === 'category' && 'Products tagged with this content category will appear in the bin.'}
               {form.filterType === 'tag' && 'Products with this Nostr t-tag will appear in the bin.'}
               {form.filterType === 'geo' && 'Products from this geographic region will appear in the bin.'}
+              {form.filterType === 'place' && "Products whose location/GPS place name contains this keyword (e.g. Hong Kong) will appear in the bin."}
               {form.filterType === 'featured' && 'Enter the d-tag IDs of specific products to feature, comma-separated.'}
             </p>
           </div>
@@ -906,6 +927,7 @@ export default function AdminMarketplace() {
               <li><strong>Category bins</strong> – show all marketplace products tagged with a specific content category (Animals, Landscape, etc.)</li>
               <li><strong>Tag bins</strong> – show products that have a specific Nostr <code>t</code>-tag value</li>
               <li><strong>Geography bins</strong> – show products from a specific continent or region</li>
+              <li><strong>Place bins</strong> – show products whose location/GPS place name matches a keyword (e.g. Hong Kong, Barcelona)</li>
               <li><strong>Featured bins</strong> – hand-pick specific product IDs to highlight</li>
               <li>Reorder bins using the ▲ ▼ arrows; toggle the eye icon to hide/show on the public page</li>
               <li>Click <strong>Save &amp; Publish</strong> to push changes live — the public marketplace page updates immediately</li>

--- a/src/pages/BinMediaWorkspace.tsx
+++ b/src/pages/BinMediaWorkspace.tsx
@@ -46,6 +46,7 @@ import {
   Loader2,
   X,
   Info,
+  MapPin,
 } from 'lucide-react';
 
 // ── Constants ──────────────────────────────────────────────────────────────────
@@ -78,6 +79,7 @@ function filterTypeIcon(ft: MarketplaceBin['filterType']) {
     case 'category': return <Tag className="w-3 h-3" />;
     case 'tag': return <Tag className="w-3 h-3" />;
     case 'geo': return <Globe className="w-3 h-3" />;
+    case 'place': return <MapPin className="w-3 h-3" />;
     case 'featured': return <Star className="w-3 h-3" />;
   }
 }
@@ -102,6 +104,14 @@ function productMatchesBin(product: MarketplaceProduct, bin: MarketplaceBin): bo
         product.country === bin.filterValue ||
         (product.geoFolder?.startsWith(bin.filterValue) ?? false)
       );
+    case 'place': {
+      const kw = bin.filterValue.trim().toLowerCase();
+      if (!kw) return false;
+      return (product.location?.toLowerCase() ?? '').includes(kw)
+        || (product.geoFolder?.toLowerCase() ?? '').includes(kw)
+        || (product.description?.toLowerCase() ?? '').includes(kw)
+        || (product.title?.toLowerCase() ?? '').includes(kw);
+    }
     case 'featured': {
       const ids = bin.filterValue.split(',').map((s) => s.trim()).filter(Boolean);
       return ids.includes(product.id);

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -17,7 +17,7 @@ import { AdminSelectionProvider, useAdminSelection } from "@/contexts/AdminSelec
 import { adminBulkDownload } from "@/lib/adminBulkDownload";
 import type { BulkDownloadProgress } from "@/lib/adminBulkDownload";
 import { PaymentDialog } from "@/components/PaymentDialog";
-import { ShoppingCart, Plus, Store, Crown, Download, CheckSquare, X, Loader2, Camera, Video, Zap, LayoutGrid, Search, Settings2 } from "lucide-react";
+import { ShoppingCart, Plus, Store, Crown, Download, CheckSquare, X, Loader2, Camera, Video, Zap, LayoutGrid, Search, Settings2, Clock } from "lucide-react";
 import { Link } from "react-router-dom";;
 import type { MarketplaceProduct } from "@/hooks/useMarketplaceProducts";
 import { ADMIN_HEX } from "@/hooks/useBlossomMedia";
@@ -118,6 +118,29 @@ function MediaThumb({ product }: { product: MarketplaceProduct }) {
   );
 }
 
+// ─── "Latest Photos" front-page strip ────────────────────────────────────────
+// Shows the newest products at the very top of /marketplace so freshly added
+// pin photos are immediately visible (the collections/grid push them down).
+function LatestPhotosSection({ products }: { products: MarketplaceProduct[] }) {
+  if (!products.length) return null;
+  return (
+    <div className="mb-5">
+      <div className="flex items-center gap-2 mb-2">
+        <Clock className="w-4 h-4" style={{ color: '#ec1a58' }} />
+        <h2 className="text-base font-bold text-gray-900 dark:text-white">Latest photos</h2>
+        <span className="text-xs text-muted-foreground">newest pin photos first</span>
+      </div>
+      <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
+        {products.map((product) => (
+          <div key={product.id} className="w-28 sm:w-32 md:w-36 flex-shrink-0">
+            <MediaThumb product={product} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // ─── Inner component so it can access AdminSelectionContext ───────────────────
 function MarketplaceInner() {
   const { user } = useCurrentUser();
@@ -154,6 +177,12 @@ function MarketplaceInner() {
   const allProducts = useMemo(
     () => infiniteData?.pages.flatMap(p => p.products) ?? [],
     [infiniteData]
+  );
+
+  // Newest products with a photo, for the front-page "Latest photos" strip.
+  const latestProducts = useMemo(
+    () => allProducts.filter(p => p.images.length > 0).slice(0, 10),
+    [allProducts]
   );
 
   useSeoMeta({
@@ -361,6 +390,11 @@ function MarketplaceInner() {
               </button>
             )}
           </div>
+
+          {/* ── Latest photos (front page) ── */}
+          {!isLoading && latestProducts.length > 0 && (
+            <LatestPhotosSection products={latestProducts} />
+          )}
 
           {/* ── Hashtag cloud ── */}
           {tagCloud.length > 0 && (

--- a/src/pages/MediaManagementHub.tsx
+++ b/src/pages/MediaManagementHub.tsx
@@ -22,7 +22,7 @@ import type { MarketplaceBin } from '@/hooks/useMarketplaceBins';
 import type { MarketplaceProduct } from '@/hooks/useMarketplaceProducts';
 import { MediaManagement } from '@/components/MediaManagement';
 import { nip19 } from 'nostr-tools';
-import { Shield, ArrowLeft, Loader2, Camera, Store, Layers, LayoutGrid, ExternalLink, CheckCircle, XCircle, Calendar, Plus, Trash2, Edit2, Save, Eye, EyeOff, GripVertical, FolderOpen, Tag, Globe, Star, ChevronUp, ChevronDown, Search, CheckCircle2, CircleDot, ImageOff, X, Info, ChevronRight } from 'lucide-react';;
+import { Shield, ArrowLeft, Loader2, Camera, Store, Layers, LayoutGrid, ExternalLink, CheckCircle, XCircle, Calendar, Plus, Trash2, Edit2, Save, Eye, EyeOff, GripVertical, FolderOpen, Tag, Globe, MapPin, Star, ChevronUp, ChevronDown, Search, CheckCircle2, CircleDot, ImageOff, X, Info, ChevronRight } from 'lucide-react';;
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -78,6 +78,7 @@ function filterTypeIcon(ft: MarketplaceBin['filterType']) {
     case 'category': return <Tag className="w-3.5 h-3.5" />;
     case 'tag': return <Tag className="w-3.5 h-3.5" />;
     case 'geo': return <Globe className="w-3.5 h-3.5" />;
+    case 'place': return <MapPin className="w-3.5 h-3.5" />;
     case 'featured': return <Star className="w-3.5 h-3.5" />;
   }
 }
@@ -87,6 +88,7 @@ function filterTypeLabel(ft: MarketplaceBin['filterType']) {
     case 'category': return 'Category';
     case 'tag': return 'Tag';
     case 'geo': return 'Geography';
+    case 'place': return 'Place';
     case 'featured': return 'Featured';
   }
 }
@@ -101,6 +103,14 @@ function productMatchesBin(product: MarketplaceProduct, bin: MarketplaceBin): bo
     }
     case 'geo':
       return product.continent === bin.filterValue || product.country === bin.filterValue;
+    case 'place': {
+      const kw = bin.filterValue.trim().toLowerCase();
+      if (!kw) return false;
+      return (product.location?.toLowerCase() ?? '').includes(kw)
+        || (product.geoFolder?.toLowerCase() ?? '').includes(kw)
+        || (product.description?.toLowerCase() ?? '').includes(kw)
+        || (product.title?.toLowerCase() ?? '').includes(kw);
+    }
     case 'featured': {
       const ids = bin.filterValue.split(',').map((s) => s.trim()).filter(Boolean);
       return ids.includes(product.id);


### PR DESCRIPTION
Fixes four things reported on /marketplace and the world map.

### /marketplace load speed
- Cache the admin-product fallback fetch (fans out to 3 public relays) across marketplace hooks and repeat visits with a short TTL, so the ~5s fetch runs once every few minutes instead of on every mount/refetch.
- Cap the per-relay fallback limit (2000 → 500) and shorten query timeouts (25s/15s → 10s).
- Drop the 60s `refetchInterval` on `useMarketplaceProducts` that re-ran the heavy fetch in the background.

### Latest pins on the front page
- Add a **"Latest photos"** strip at the very top of `/marketplace` showing the newest pin photos, so freshly added pins are visible above the Collections section and grid.

### Hong Kong / wrong collection
- Add a new **`Place`** bin filter type: a case-insensitive keyword matched against a listing's `location`/GPS place name (e.g. `Hong Kong`). Lets the admin set the Hong Kong collection to match by place instead of a content category, so the real HK photos land in it. Wired through the public bin section, the Marketplace Editor, Bin Media Workspace, and Media Management Hub.
- Bump bin product fetch 12 → 40 so category/geo/place bins are more likely to match recently uploaded photos.

### World-map / feed thumbnails (e.g. "Mountain in the Bicaz Gorge")
- `OptimizedImage` routed Primal/blossom sources at full original size (no resize), which made map/feed thumbnails slow or fail. It now routes them through the Weserv resize proxy to a small WebP, matching the marketplace grid behavior.

`tsc`, `eslint`, `vitest` and a production build all pass on `144c5a7`.

After merge, the admin sets the Hong Kong collection via **Admin → Marketplace Editor → edit "Hong Kong" → Filter type: Place → "Hong Kong" → Save & Publish**.
