### PR TITLE
Stop auto-listing review photos on /marketplace

### DIFF
--- a/src/components/CreateReviewForm.tsx
+++ b/src/components/CreateReviewForm.tsx
@@ -430,39 +430,6 @@ ${data.content || data.description || ''}
 
       createEvent(clawstrEvent);
 
-      // Automatically publish companion marketplace listing (kind 30402) so every pin photo/video is for sale
-      if (imageUrl) {
-        const DEFAULT_SALE_PRICE = '0.99';
-        const DEFAULT_SALE_CURRENCY = 'USD';
-        const productId = `product_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-        const marketplaceTags: string[][] = [
-          ['d', productId],
-          ['title', data.title],
-          ['summary', (data.description || data.content || '').slice(0, 200)],
-          ['price', DEFAULT_SALE_PRICE, DEFAULT_SALE_CURRENCY],
-          ['t', 'photos'], // media type tag for filtering
-          ['category', data.category], // content category
-          ['status', 'active'],
-          ['published_at', Math.floor(Date.now() / 1000).toString()],
-          ['image', imageUrl],
-        ];
-
-        if (data.location) marketplaceTags.push(['location', data.location]);
-        if (location) {
-          marketplaceTags.push(['g', encodeGeohash(location.lat, location.lng)]);
-        }
-        // Additional photos / video thumbnails
-        additionalPhotos.forEach((photoUrl) => {
-          marketplaceTags.push(['image', photoUrl]);
-        });
-
-        createEvent({
-          kind: 30402, // NIP-99 classified listing
-          content: data.description || data.content || '',
-          tags: marketplaceTags,
-        });
-      }
-
       toast({
         title: 'Review published!',
         description: 'Your review has been shared on Nostr, Clawstr, and is visible on all clients.',

--- a/src/hooks/useMarketplaceProducts.ts
+++ b/src/hooks/useMarketplaceProducts.ts
@@ -188,8 +188,30 @@ function isValidProduct(event: NostrEvent): boolean {
 }
 
 /**
- * Check whether a product event should be treated as deleted.
+ * Identify review-photo auto-listings.
+ *
+ * The CreateReview flow auto-publishes a companion marketplace listing
+ * (`d=product_…`, price 0.99) for every review photo. These are NOT real
+ * products and should not appear on /marketplace — the user asked to keep
+ * review photos out of the marketplace feed (they were popping up between
+ * the map-pin listings).
+ *
+ * They are distinguishable from legitimate products because:
+ *  - Real products created via the Marketplace editor always carry
+ *    `continent`/`country`/`geo_folder` (required by form validation) and/or a
+ *    `review` tag (map pins). Review-photo auto-lists have NONE of these.
+ *  - Their `d` value starts with `product_`.
  */
+function isReviewPhotoListing(event: NostrEvent): boolean {
+  const d = event.tags.find(([n]) => n === 'd')?.[1] ?? '';
+  if (!d.startsWith('product_')) return false;
+
+  const hasReview = event.tags.some(([n]) => n === 'review');
+  const hasContinent = event.tags.some(([n]) => n === 'continent');
+  const hasGeoFolder = event.tags.some(([n]) => n === 'geo_folder');
+  return !hasReview && !hasContinent && !hasGeoFolder;
+}
+
 function isDeleted(event: NostrEvent): boolean {
   const status = event.tags.find(([n]) => n === 'status')?.[1];
   if (status === 'deleted') return true;
@@ -303,6 +325,7 @@ export function useMarketplaceProducts(options: UseMarketplaceProductsOptions = 
       for (const event of events) {
         if (!isValidProduct(event)) continue;
         if (isDeleted(event)) continue;
+        if (isReviewPhotoListing(event)) continue;
 
         const product = parseProduct(event);
         if (!product) continue;
@@ -396,6 +419,7 @@ export function useInfiniteMarketplaceProducts(options: UseMarketplaceProductsOp
       for (const event of seen.values()) {
         if (!isValidProduct(event)) continue;
         if (isDeleted(event)) continue;
+        if (isReviewPhotoListing(event)) continue;
 
         const product = parseProduct(event);
         if (!product) continue;


### PR DESCRIPTION
Fixes BitPopArt request: review photos were appearing between the map-pin photos on /marketplace.

**Root cause:** the create-review flow (CreateReviewForm) auto-published a companion marketplace listing (kind 30402, d=product_..., price 0.99) for every review photo — they then sat at the top of /marketplace between the real map-pin listings.

**Fix (two layers):**
1. CreateReviewForm no longer auto-publishes a marketplace listing when a photo is uploaded.
2. Defense-in-depth: useMarketplaceProducts excludes any listing whose d-tag starts with `product_` and has no `review`/`continent`/`geo_folder` tag. Real products always carry continent/geo (form-required) and map pins carry `review`, so only review-photo auto-lists are filtered. Applied in both standard + infinite hooks.

tsc, eslint, vitest and production build all pass.