### PR TITLE
Marketplace: Latest photos shows pin photos only, excludes review photos

### DIFF
--- a/public/telly-map.html
+++ b/public/telly-map.html
@@ -1653,6 +1653,7 @@ $('pubbtn').onclick = async () => {
         ['price',    '0.99', 'USD'],
         ['t',        'photos'],
         ['category', 'landmarks'],
+        ['type',     'pin'],
         ['status',   'active'],
         ['published_at', String(Math.floor(Date.now()/1000))],
         ['image',    imageUrl],

--- a/src/components/AdminMapPinBackfill.tsx
+++ b/src/components/AdminMapPinBackfill.tsx
@@ -1,10 +1,10 @@
 /**
  * AdminMapPinBackfill
  * ────────────────────
- * Scans existing kind 34879 travel reviews that became world-map pins
- * (have an `image` + `g` geohash tag) and publishes a companion NIP-99
- * marketplace listing (kind 30402) at the default $0.99 USD price for any
- * that aren't already listed.
+ * Scans existing kind 34879 photo pins that became world-map pins
+ * (have a `type=pin` tag, an `image` and a `g` geohash) and publishes a
+ * companion NIP-99 marketplace listing (kind 30402) at the default $0.99 USD
+ * price for any that aren't already listed.
  *
  * Why an admin action: a backfill must be signed by an authorized uploader,
  * and the server/agent key is not an authorized uploader for /marketplace.
@@ -144,6 +144,10 @@ export function AdminMapPinBackfill() {
       const pins: PinReview[] = [];
       let skipCount = 0;
       for (const ev of validReviews) {
+        // Only backfill actual world-map PIN photos. Travel REVIEWS (kind 34879
+        // without `type=pin`) belong to /reviews and are not for sale, so they
+        // must never be listed on /marketplace.
+        if (ev.tags.find(([n]) => n === 'type')?.[1] !== 'pin') continue;
         const pin = reviewToPin(ev);
         if (!pin) continue;
         const expectedD = `map_pin_${pin.slug}`;
@@ -190,6 +194,9 @@ export function AdminMapPinBackfill() {
             ['price', DEFAULT_SALE_PRICE, DEFAULT_SALE_CURRENCY],
             ['t', 'photos'],
             ['category', pin.category],
+            // Self-describe as a PIN photo so /marketplace can tell pins apart
+            // from (excluded) review photos without resolving the source event.
+            ['type', 'pin'],
             ['status', 'active'],
             ['published_at', Math.floor(Date.now() / 1000).toString()],
           ];

--- a/src/hooks/useMarketplaceProducts.ts
+++ b/src/hooks/useMarketplaceProducts.ts
@@ -188,28 +188,31 @@ function isValidProduct(event: NostrEvent): boolean {
 }
 
 /**
- * Identify review-photo auto-listings.
+ * Identify review-photo listings — listings on /marketplace that were derived
+ * from a travel REVIEW rather than a world-map PIN, and are therefore not for
+ * sale (they belong to the /reviews page).
  *
- * The CreateReview flow auto-publishes a companion marketplace listing
- * (`d=product_…`, price 0.99) for every review photo. These are NOT real
- * products and should not appear on /marketplace — the user asked to keep
- * review photos out of the marketplace feed (they were popping up between
- * the map-pin listings).
+ * The site's own "pin vs review" semantic is the `type` tag on the source
+ * review event (kind 34879): photo PINs carry `type=pin`; REVIEWS carry no
+ * `type` tag. The marketplace feed should carry listings only for PIN photos.
  *
- * They are distinguishable from legitimate products because:
- *  - Real products created via the Marketplace editor always carry
- *    `continent`/`country`/`geo_folder` (required by form validation) and/or a
- *    `review` tag (map pins). Review-photo auto-lists have NONE of these.
- *  - Their `d` value starts with `product_`.
+ * Distinguishing them on the listing (kind 30402):
+ *  - Listings created by the admin pin-backfill copy the source review's slug
+ *    into a `review` tag (and into `d` as `map_pin_<slug>`). Review-derived
+ *    listings reference the review-flow slug pattern `review-<ts>-<rand>`;
+ *    photo-pin listings reference a human-readable pin slug.
+ *  - Going forward listings are stamped with a `type` tag so they self-describe.
+ *  - A `d = product_…` prefix alone is NOT a review marker: the telly-map pin
+ *    tool and real Marketplace uploads also use it, so we must not exclude on
+ *    that basis (doing so hid real pins/products while missing review photos).
  */
 function isReviewPhotoListing(event: NostrEvent): boolean {
-  const d = event.tags.find(([n]) => n === 'd')?.[1] ?? '';
-  if (!d.startsWith('product_')) return false;
+  const type = event.tags.find(([n]) => n === 'type')?.[1];
+  if (type) return type === 'review';
 
-  const hasReview = event.tags.some(([n]) => n === 'review');
-  const hasContinent = event.tags.some(([n]) => n === 'continent');
-  const hasGeoFolder = event.tags.some(([n]) => n === 'geo_folder');
-  return !hasReview && !hasContinent && !hasGeoFolder;
+  const d = event.tags.find(([n]) => n === 'd')?.[1] ?? '';
+  const reviewRef = event.tags.find(([n]) => n === 'review')?.[1] ?? '';
+  return d.startsWith('map_pin_review-') || reviewRef.startsWith('review-');
 }
 
 function isDeleted(event: NostrEvent): boolean {


### PR DESCRIPTION
Marketplace: the **Latest photos** strip and the whole feed now show **only pin photos** (newest first) and exclude **review photos**.

**Symptom**: /marketplace was showing `map_pin_review-*` listings (backfilled from travel REVIEWS - e.g. cafes/co-workings that belong to /reviews and are not for sale) filling the Latest photos strip ahead of the real pin photos.

**Fix**:
1. `useMarketplaceProducts` - rewrote `isReviewPhotoListing` to detect review listings by source (`type=review` or legacy `map_pin_review-*`/`review-*` review slugs) instead of the `product_` + no-geo heuristic, which had missed review photos while wrongly hiding real pins/products. Real pin photos (telly-map pins, backfill `map_pin_<slug>`, marketplace uploads) are kept.
2. `AdminMapPinBackfill` - only backfills actual world-map PIN photos (source has `type=pin`); REVIEWS are never listed for sale; listings stamped `type=pin`.
3. `telly-map.html` - auto-listed pin listings stamped `type=pin`.

Verified against live relay data: all 15 review listings excluded; newest 10 feed photos are pin photos.
tsc, eslint, vitest and vite build pass.