### PR TITLE
Marketplace: location-only tag cloud + faster repeat loads

### DIFF
--- a/src/hooks/useMarketplaceProducts.ts
+++ b/src/hooks/useMarketplaceProducts.ts
@@ -19,11 +19,43 @@ const MARKETPLACE_FALLBACK_RELAYS = [
 /**
  * The admin-product fallback fetch is expensive (fans out to 3 public relays
  * and can transfer ~1000 events each). Deduplicate it across ALL marketplace
- * hooks and repeat visits with a short TTL cache, so /marketplace only pays the
- * cost once every few minutes instead of on every mount/refetch.
+ * hooks and repeat visits with a cached result, so /marketplace only pays the
+ * cost on a genuinely cold load instead of on every mount/refetch.
+ *
+ * The in-memory cache lives for the module's lifetime (the SPA session); on top
+ * of that we persist to localStorage so a fresh page load / repeat visit within
+ * the TTL reuses the prior fan-out instead of blocking on 3 relays again — this
+ * is the biggest remaining "page is slow" win for /marketplace.
  */
-const FALLBACK_CACHE_TTL_MS = 5 * 60 * 1000;
+const FALLBACK_CACHE_TTL_MS = 30 * 60 * 1000;
+const FALLBACK_CACHE_KEY = 'traveltelly_admin_products_cache_v1';
 let fallbackCache: { at: number; events: NostrEvent[] } | null = null;
+
+function loadFallbackCacheFromStorage(): { at: number; events: NostrEvent[] } | null {
+  try {
+    const raw = localStorage.getItem(FALLBACK_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.at === 'number' && Array.isArray(parsed.events)) {
+      return { at: parsed.at, events: parsed.events };
+    }
+  } catch {
+    // Unreadable/corrupt/private-mode storage — fall through to in-memory.
+  }
+  return null;
+}
+
+function saveFallbackCacheToStorage(cache: { at: number; events: NostrEvent[] } | null) {
+  try {
+    if (cache) {
+      localStorage.setItem(FALLBACK_CACHE_KEY, JSON.stringify(cache));
+    } else {
+      localStorage.removeItem(FALLBACK_CACHE_KEY);
+    }
+  } catch {
+    // Quota exceeded / storage disabled — in-memory cache still works.
+  }
+}
 
 /**
  * Query kind 30402 events by the admin pubkey directly from a set of relays,
@@ -60,15 +92,24 @@ async function queryAdminProductsFromRelays(signal: AbortSignal): Promise<NostrE
   return Array.from(seen.values());
 }
 
-/** Cached wrapper around queryAdminProductsFromRelays. */
+/** Cached wrapper around queryAdminProductsFromRelays, memory + localStorage. */
 async function getAdminProductsCached(signal: AbortSignal): Promise<NostrEvent[]> {
   const now = Date.now();
   if (fallbackCache && now - fallbackCache.at < FALLBACK_CACHE_TTL_MS) {
     return fallbackCache.events;
   }
+  // Rehydrate the persisted fan-out instead of re-fetching on a fresh load.
+  if (!fallbackCache) {
+    const stored = loadFallbackCacheFromStorage();
+    if (stored && now - stored.at < FALLBACK_CACHE_TTL_MS) {
+      fallbackCache = stored;
+      return stored.events;
+    }
+  }
   const events = await queryAdminProductsFromRelays(signal);
   if (events.length > 0) {
     fallbackCache = { at: now, events };
+    saveFallbackCacheToStorage(fallbackCache);
   }
   return events;
 }

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -206,19 +206,15 @@ function MarketplaceInner() {
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  // Build hashtag cloud from loaded products
+  // Build the location tag cloud from loaded products. Only geographic
+  // classification tags are shown — the product's continent, country and
+  // city (location) — never generic content hashtags (sunset, nature, …).
   const tagCloud = useMemo(() => {
     if (!allProducts.length) return [];
     const counts = new Map<string, number>();
     for (const p of allProducts) {
-      for (const [name, val] of p.event.tags) {
-        if (name === 't' && val) {
-          counts.set(val, (counts.get(val) || 0) + 1);
-        }
-      }
-      if (p.contentCategory) {
-        const slug = p.contentCategory.toLowerCase().replace(/\s+/g, '-');
-        counts.set(slug, (counts.get(slug) || 0) + 1);
+      for (const v of [p.continent, p.country, p.location]) {
+        if (v) counts.set(v, (counts.get(v) || 0) + 1);
       }
     }
     return Array.from(counts.entries())
@@ -234,9 +230,11 @@ function MarketplaceInner() {
       if (activeType === 'photos' && (p.mediaType === 'video' || p.images[0]?.match(/\.(mp4|webm|mov)/i))) return false;
       if (activeType === 'videos' && !(p.mediaType === 'video' || p.images[0]?.match(/\.(mp4|webm|mov)/i))) return false;
       if (activeTag) {
-        const tags = p.event.tags.filter(([n]) => n === 't').map(([, v]) => v);
-        const catSlug = p.contentCategory?.toLowerCase().replace(/\s+/g, '-');
-        if (!tags.includes(activeTag) && catSlug !== activeTag) return false;
+        const matches =
+          p.continent === activeTag ||
+          p.country === activeTag ||
+          p.location === activeTag;
+        if (!matches) return false;
       }
       return true;
     });


### PR DESCRIPTION
Addresses BitPopArt's feedback on /marketplace:
1. The tag cloud now shows only geographic classification tags — the product's continent, country and city (location) — instead of arbitrary content hashtags (sunset, nature, etc.). Filtering matches against those same three fields. (Marketplace.tsx)
2. Speed: persist the admin-product fallback relay fetch to localStorage (30min TTL) on top of the existing in-memory cache, so a fresh page load / repeat visit reuses the prior 3-relay fan-out instead of blocking on it again — the biggest remaining 'still too slow' cost on /marketplace. Malformed/quota-exceeded storage degrades gracefully to the in-memory cache. (useMarketplaceProducts.ts)

tsc, eslint, vitest and a production build all pass.