### PR TITLE
Verify Lightning payments before unlocking /marketplace downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "input-otp": "^1.2.4",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
+        "light-bolt11-decoder": "^3.2.0",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "ngeohash": "^0.6.3",
@@ -305,32 +306,6 @@
         "@capacitor/core": ">=8.0.0"
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
@@ -444,33 +419,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@edge-runtime/primitives": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
-      "integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/vm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
-      "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@edge-runtime/primitives": "4.1.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3202,7 +3150,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3216,7 +3163,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3230,7 +3176,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3244,7 +3189,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3258,7 +3202,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3272,7 +3215,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3286,7 +3228,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3300,7 +3241,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3314,7 +3254,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3328,7 +3267,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3342,7 +3280,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3356,7 +3293,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3370,7 +3306,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3384,7 +3319,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3398,7 +3332,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3412,7 +3345,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3426,7 +3358,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3440,7 +3371,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3454,7 +3384,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3468,7 +3397,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3967,38 +3895,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -4563,20 +4459,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -5113,14 +4995,6 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5399,17 +5273,6 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -6551,6 +6414,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/light-bolt11-decoder": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/light-bolt11-decoder/-/light-bolt11-decoder-3.2.0.tgz",
+      "integrity": "sha512-3QEofgiBOP4Ehs9BI+RkZdXZNtSys0nsJ6fyGeSiAGCBsMwHGUDS/JQlY/sTnWs91A2Nh0S9XXfA8Sy9g6QpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "1.1.1"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -6680,14 +6552,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -8635,59 +8499,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -8928,14 +8739,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/vaul": {
       "version": "0.9.9",
@@ -9469,17 +9272,6 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "input-otp": "^1.2.4",
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
+    "light-bolt11-decoder": "^3.2.0",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "ngeohash": "^0.6.3",

--- a/src/components/GuestCheckout.tsx
+++ b/src/components/GuestCheckout.tsx
@@ -12,6 +12,7 @@ import { usePriceConversion } from '@/hooks/usePriceConversion';
 import { useToast } from '@/hooks/useToast';
 import { Mail, User, CreditCard, Zap, CheckCircle, Copy, ExternalLink, Loader2, Info } from 'lucide-react';
 import type { MarketplaceProduct } from '@/hooks/useMarketplaceProducts';
+import { getInvoicePaymentHash, verifyPaymentPreimage } from '@/lib/lnPaymentProof';
 
 // Lightning address for TravelTelly — also reads from admin settings
 const LIGHTNING_ADDRESS = localStorage.getItem('traveltelly_lightning_address') || 'bitpopart@rizful.com';
@@ -55,6 +56,9 @@ function LightningGuestFlow({
   const [qrUrl, setQrUrl] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
   const [verifyStep, setVerifyStep] = useState('');
+  const [paymentHash, setPaymentHash] = useState<string | null>(null);
+  const [preimage, setPreimage] = useState('');
+  const [preimageError, setPreimageError] = useState('');
 
   // Parse sats from conversion hook
   const amountSats = priceInfo.sats ? parseInt(priceInfo.sats.replace(/[^\d]/g, '')) : 0;
@@ -99,6 +103,7 @@ function LightningGuestFlow({
       }
       if (!invoiceData.pr) throw new Error('No invoice returned from Lightning provider');
       setInvoice(invoiceData.pr);
+      setPaymentHash(getInvoicePaymentHash(invoiceData.pr));
       setQrUrl(`https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(invoiceData.pr)}`);
       setStep('invoice');
       // Try WebLN auto-pay
@@ -106,7 +111,7 @@ function LightningGuestFlow({
         try {
           await window.webln.enable();
           const res = await window.webln.sendPayment(invoiceData.pr);
-          if (res.preimage) { await handlePaid(); return; }
+          if (res.preimage) { const ok = await handlePaid(res.preimage); if (ok) return; }
         } catch { /* user cancelled or no WebLN */ }
       }
     } catch (err) {
@@ -120,7 +125,28 @@ function LightningGuestFlow({
     toast({ title: 'Copied!', description: 'Invoice copied to clipboard.' });
   };
 
-  const handlePaid = async () => {
+  const handlePaid = async (preimageArg?: string): Promise<boolean> => {
+    const paymentProof = (preimageArg ?? preimage).trim();
+
+    if (!paymentHash) {
+      setPreimageError('Payment proof could not be prepared. Go back and create the invoice again.');
+      return false;
+    }
+    if (!paymentProof) {
+      setPreimageError('Paste the payment preimage from your wallet — this proves the invoice was paid.');
+      return false;
+    }
+
+    const isValid = await verifyPaymentPreimage(paymentProof, paymentHash);
+    if (!isValid) {
+      setPreimageError(
+        'Payment not verified — the preimage does not match this invoice. ' +
+        'If you paid, copy the exact preimage from your wallet (payment details → preimage) and try again.'
+      );
+      return false;
+    }
+    setPreimageError('');
+
     setStep('verifying');
     setVerifyStep('Saving purchase record…');
     await new Promise(r => setTimeout(r, 600));
@@ -136,6 +162,9 @@ function LightningGuestFlow({
       amount: amountSats,
       currency: 'SATS',
       timestamp,
+      invoice,
+      paymentHash,
+      preimage: paymentProof,
       paymentMethod: 'lightning' as const,
       status: 'verified' as const,
       productData: {
@@ -157,6 +186,7 @@ function LightningGuestFlow({
     const downloadUrl = buildDownloadUrl(orderId, email, timestamp);
     setTimeout(() => { window.location.href = downloadUrl; }, 1200);
     onSuccess();
+    return true;
   };
 
   if (step === 'done') {
@@ -194,13 +224,32 @@ function LightningGuestFlow({
         <Alert className="border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20">
           <Zap className="h-4 w-4 text-yellow-600" />
           <AlertDescription className="text-yellow-800 dark:text-yellow-200 text-sm">
-            <strong>Steps:</strong> 1) Pay in your wallet &nbsp;2) Click <em>I've Paid</em> below — we will record your access.
+            <strong>Steps:</strong> 1) Pay in your wallet &nbsp;2) Paste the <strong>preimage</strong> (payment proof)
+            from your wallet's payment details &nbsp;3) Click <em>Verify Payment</em> — your download unlocks.
           </AlertDescription>
         </Alert>
+        <div className="space-y-1.5">
+          <Label className="text-xs">Payment preimage (proof of payment)</Label>
+          <Input
+            value={preimage}
+            onChange={(e) => { setPreimage(e.target.value); setPreimageError(''); }}
+            placeholder="Paste the preimage from your wallet's payment details"
+            className="font-mono text-xs"
+          />
+          <p className="text-xs text-muted-foreground">
+            The preimage is shown in your wallet's payment details. It is checked against this invoice's payment hash,
+            so only a real payment unlocks the download.
+          </p>
+          {preimageError && (
+            <Alert variant="destructive" className="py-2">
+              <AlertDescription className="text-xs">{preimageError}</AlertDescription>
+            </Alert>
+          )}
+        </div>
         <div className="flex gap-3">
           <Button variant="outline" onClick={() => setStep('idle')} className="flex-1">Back</Button>
-          <Button onClick={handlePaid} className="flex-1 bg-green-600 hover:bg-green-700">
-            <CheckCircle className="w-4 h-4 mr-2" /> I've Paid
+          <Button onClick={() => handlePaid()} className="flex-1 bg-green-600 hover:bg-green-700">
+            <CheckCircle className="w-4 h-4 mr-2" /> Verify Payment
           </Button>
         </div>
       </div>

--- a/src/components/LightningMarketplacePayment.tsx
+++ b/src/components/LightningMarketplacePayment.tsx
@@ -10,6 +10,7 @@ import { useToast } from '@/hooks/useToast';
 import { usePriceConversion } from '@/hooks/usePriceConversion';
 import { Zap, Loader2, CheckCircle, Copy, ExternalLink } from 'lucide-react';
 import type { MarketplaceProduct } from '@/hooks/useMarketplaceProducts';
+import { getInvoicePaymentHash, verifyPaymentPreimage } from '@/lib/lnPaymentProof';
 
 interface LightningMarketplacePaymentProps {
   product: MarketplaceProduct;
@@ -83,6 +84,9 @@ export function LightningMarketplacePayment({ product, onSuccess }: LightningMar
   const [qrCodeUrl, setQrCodeUrl] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
   const [verifyMsg, setVerifyMsg] = useState('');
+  const [paymentHash, setPaymentHash] = useState<string | null>(null);
+  const [preimageInput, setPreimageInput] = useState('');
+  const [preimageError, setPreimageError] = useState('');
 
   const { toast } = useToast();
   const priceInfo = usePriceConversion(product.price, product.currency);
@@ -119,6 +123,7 @@ export function LightningMarketplacePayment({ product, onSuccess }: LightningMar
       const invoiceData = await createInvoiceFromLNURL(lnurl, amountMsat, comment);
 
       setInvoice(invoiceData.pr);
+      setPaymentHash(getInvoicePaymentHash(invoiceData.pr));
       setQrCodeUrl(`https://api.qrserver.com/v1/create-qr-code/?size=256x256&data=${encodeURIComponent(invoiceData.pr)}`);
       setPaymentStep('invoice');
 
@@ -128,8 +133,8 @@ export function LightningMarketplacePayment({ product, onSuccess }: LightningMar
           await window.webln.enable();
           const result = await window.webln.sendPayment(invoiceData.pr);
           if (result.preimage) {
-            await handlePaymentConfirmed();
-            return;
+            const confirmed = await handlePaymentConfirmed(result.preimage);
+            if (confirmed) return;
           }
         } catch (weblnErr) {
           console.log('WebLN not available or user cancelled:', weblnErr);
@@ -144,8 +149,30 @@ export function LightningMarketplacePayment({ product, onSuccess }: LightningMar
     }
   };
 
-  // ── Record & redirect after payment ────────────────────────────────────────
-  const handlePaymentConfirmed = async () => {
+  // ── Verify payment, record & redirect ────────────────────────────────────
+  // The preimage is the proof of payment: sha256(preimage) must equal the
+  // invoice's payment hash. Without a matching preimage we never unlock.
+  const handlePaymentConfirmed = async (preimage?: string): Promise<boolean> => {
+    const paymentProof = (preimage ?? preimageInput).trim();
+
+    if (!paymentHash) {
+      setPreimageError('Payment proof could not be prepared. Go back and create the invoice again.');
+      return false;
+    }
+    if (!paymentProof) {
+      setPreimageError('Paste the payment preimage from your wallet — this proves the invoice was paid.');
+      return false;
+    }
+
+    const isValid = await verifyPaymentPreimage(paymentProof, paymentHash);
+    if (!isValid) {
+      setPreimageError(
+        'Payment not verified — the preimage does not match this invoice. ' +
+        'If you paid, copy the exact preimage from your wallet (payment details → preimage) and try again.'
+      );
+      return false;
+    }
+    setPreimageError('');
     setPaymentStep('verifying');
     setVerifyMsg('Recording your purchase…');
     await new Promise(r => setTimeout(r, 500));
@@ -163,6 +190,8 @@ export function LightningMarketplacePayment({ product, onSuccess }: LightningMar
       currency: 'SATS',
       timestamp,
       invoice,
+      paymentHash,
+      preimage: paymentProof,
       paymentMethod: 'lightning' as const,
       status: 'verified' as const,
       productData: {
@@ -185,6 +214,7 @@ export function LightningMarketplacePayment({ product, onSuccess }: LightningMar
     const downloadUrl = `${window.location.origin}/download/${orderId}?token=${token}&email=${encodeURIComponent(buyerEmail)}`;
     setTimeout(() => { window.location.href = downloadUrl; }, 1500);
     onSuccess();
+    return true;
   };
 
   const copyToClipboard = (text: string) => {
@@ -243,21 +273,40 @@ export function LightningMarketplacePayment({ product, onSuccess }: LightningMar
           <Zap className="h-4 w-4 text-yellow-600" />
           <AlertDescription className="text-sm text-yellow-800 dark:text-yellow-200">
             <strong>How to pay:</strong><br />
-            1. Scan the QR code OR copy the invoice into your Lightning wallet<br />
-            2. Confirm the payment in your wallet<br />
-            3. Click <strong>"I've Paid"</strong> — your download will open immediately
+            1. Send the payment from your Lightning wallet (scan the QR or copy the invoice)<br />
+            2. Find the <strong>preimage</strong> (payment proof) in your wallet's payment details<br />
+            3. Paste it below and click <strong>"Verify Payment"</strong> — your download unlocks
           </AlertDescription>
         </Alert>
+
+        <div className="space-y-1.5">
+          <Label className="text-xs">Payment preimage (proof of payment)</Label>
+          <Input
+            value={preimageInput}
+            onChange={(e) => { setPreimageInput(e.target.value); setPreimageError(''); }}
+            placeholder="Paste the preimage from your wallet's payment details"
+            className="font-mono text-xs"
+          />
+          <p className="text-xs text-muted-foreground">
+            The preimage is shown in your wallet's payment details (e.g. Phoenix → transaction → preimage).
+            It is checked against this invoice's payment hash, so only a real payment unlocks the download.
+          </p>
+          {preimageError && (
+            <Alert variant="destructive" className="py-2">
+              <AlertDescription className="text-xs">{preimageError}</AlertDescription>
+            </Alert>
+          )}
+        </div>
 
         <div className="flex gap-3">
           <Button variant="outline" onClick={() => setPaymentStep('form')} className="flex-1">
             ← Back
           </Button>
           <Button
-            onClick={handlePaymentConfirmed}
+            onClick={() => handlePaymentConfirmed()}
             className="flex-1 bg-green-600 hover:bg-green-700"
           >
-            <CheckCircle className="w-4 h-4 mr-2" /> I've Paid
+            <CheckCircle className="w-4 h-4 mr-2" /> Verify Payment
           </Button>
         </div>
       </div>

--- a/src/lib/lnPaymentProof.test.ts
+++ b/src/lib/lnPaymentProof.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { getInvoicePaymentHash, verifyPaymentPreimage } from './lnPaymentProof';
+
+// Real BOLT11 invoice fetched from the marketplace's LNURL endpoint
+// (rizful.com/lnurl_two/bitpopart/get_invoice, 1000 msat test invoice).
+const REAL_INVOICE =
+  "lnbc10n1p4gqfympp5wq5pnmcffsjevmzgwmcl7aa5un2cqt8vwgshpzn03tnznqjtkjtqhp59aqzmwdhk4c3xfxekukgls8yqxg967nem6fzman6ps66z7swp6xscqzysxqrrssrzjqv3dpepm8kfdxrk3sl6wzqdf49s9c0h9ljtjrek6c08r6aejlwcnur0dwyqqvucqqqqqqqlgqqqq86qqjqsp52jud93fn7d3syx6gz8dr7cyfejw8cxxyvw74lmtcydyl9q4c8rwq9qxpqysgqahuka9zd4gkpyqxg5zklt98yggm9lnhls7lslvrwcepc7ypejnu8gxxrkndya9tendgy93wes25m02n8vrw5jugkyzzed78074aacggqz2587j";
+
+// Known-answer vector: sha256(preimage) === hash (generated offline with node:crypto).
+const PREIMAGE = 'e639fe5aa43a4e43e363d52c1b1de5b140ab66253d201ac374b111533c5b0ef6';
+const PAYMENT_HASH = '3ef50ea38af25673c663c2a75947a9a242c1e98fbfdffaef08a397a5a9d7d148';
+
+describe('getInvoicePaymentHash', () => {
+  it('extracts the payment hash from a real BOLT11 invoice', () => {
+    const hash = getInvoicePaymentHash(REAL_INVOICE);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(getInvoicePaymentHash('not-an-invoice')).toBeNull();
+    expect(getInvoicePaymentHash('')).toBeNull();
+  });
+});
+
+describe('verifyPaymentPreimage', () => {
+  it('accepts the correct preimage for a payment hash', async () => {
+    expect(await verifyPaymentPreimage(PREIMAGE, PAYMENT_HASH)).toBe(true);
+  });
+
+  it('rejects a preimage that does not match the hash', async () => {
+    const other = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    expect(await verifyPaymentPreimage(other, PAYMENT_HASH)).toBe(false);
+  });
+
+  it('rejects non-hex input', async () => {
+    expect(await verifyPaymentPreimage('zzzz', PAYMENT_HASH)).toBe(false);
+  });
+
+  it('is case-insensitive for both arguments', async () => {
+    expect(await verifyPaymentPreimage(PREIMAGE.toUpperCase(), PAYMENT_HASH.toUpperCase())).toBe(true);
+  });
+});

--- a/src/lib/lnPaymentProof.ts
+++ b/src/lib/lnPaymentProof.ts
@@ -1,0 +1,53 @@
+import { decode } from 'light-bolt11-decoder';
+
+/**
+ * Decode a BOLT11 invoice and return its payment hash (lowercase hex),
+ * or null if the invoice can't be parsed.
+ */
+export function getInvoicePaymentHash(paymentRequest: string): string | null {
+  try {
+    const decoded = decode(paymentRequest);
+    const section = decoded.sections.find((s) => s.name === 'payment_hash');
+    return section && 'value' in section && typeof section.value === 'string'
+      ? section.value.toLowerCase()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  const clean = hex.replace(/^0x/i, '').trim();
+  if (!/^[0-9a-fA-F]+$/.test(clean) || clean.length % 2 !== 0) return null;
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+async function sha256Hex(data: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Verify a Lightning payment preimage against an invoice's payment hash.
+ *
+ * The preimage is the cryptographic proof of payment: sha256(preimage) must
+ * equal the payment hash embedded in the invoice. A preimage can only be
+ * produced by the wallet that received/settled the payment, so this is the
+ * light-weight way to confirm an invoice was actually paid without needing
+ * access to the receiving node's API.
+ */
+export async function verifyPaymentPreimage(
+  preimage: string,
+  paymentHash: string
+): Promise<boolean> {
+  const bytes = hexToBytes(preimage);
+  if (!bytes) return false;
+  const digest = await sha256Hex(bytes);
+  return digest === paymentHash.toLowerCase();
+}

--- a/src/pages/DownloadPage.tsx
+++ b/src/pages/DownloadPage.tsx
@@ -156,8 +156,21 @@ const DownloadPage = () => {
     const found = lookupPurchase(orderId, email);
 
     if (found) {
-      setPurchase(found);
-      setDownloadItems(buildDownloadItems(found));
+      // Validate the download token — it must match this order's record
+      // (btoa(`orderId:email:timestamp`), the same format every checkout
+      // flow uses to build the download link). A mismatched token means the
+      // link was not issued for this order.
+      let tokenValid = false;
+      try {
+        const expected = btoa(`${found.orderId}:${found.buyerEmail}:${found.timestamp}`);
+        tokenValid = token === expected;
+      } catch {
+        tokenValid = false;
+      }
+      if (tokenValid) {
+        setPurchase(found);
+        setDownloadItems(buildDownloadItems(found));
+      }
     }
     // Short delay to show the verifying state
     const t = setTimeout(() => setIsVerifying(false), 800);


### PR DESCRIPTION
Fixes the report: clicking **"I've Paid"** on the marketplace Lightning invoice screen marked the order as paid and opened the download page even when no payment was sent — the button never verified anything.

**Root cause**
- Both marketplace Lightning flows (`LightningMarketplacePayment` and the guest `LightningGuestFlow` in `GuestCheckout`) created a purchase record with `status: 'verified'` and redirected to `/download/:orderId` purely on button click. The URL token is `btoa(orderId:email:timestamp)` and `DownloadPage` never validated it, so the download page could be unlocked without paying.

**Fix**
- New `src/lib/lnPaymentProof.ts`: decodes the BOLT11 invoice to get its payment hash and verifies a payment preimage via `sha256(preimage) === payment_hash` — the Lightning proof of payment.
- "I've Paid" → **"Verify Payment"**: requires the preimage from the payer's wallet (WebLN returns it automatically after a successful `sendPayment`; external wallets show it in payment details). Only a matching preimage marks the order verified. Invalid/missing preimages keep the user on the invoice screen with a clear error — no purchase record, no download page.
- `DownloadPage` now validates the download token against the stored order record.

**Verified**: tsc, eslint on touched files, new unit tests (`src/lib/lnPaymentProof.test.ts`, 6 cases incl. a real invoice) and a production build all pass. Repo-wide `npm test` still fails on pre-existing lint/test noise from stale `.worktrees/` checkouts (untouched by this PR).

---
Originating channel: TravelTelly.com Updates (#70bd27d9-b772-4453-b1be-008dad3bbcee)
