### PR TITLE
Keep homepage at / — map only at /telly-map

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { ScrollToTop } from "./components/ScrollToTop";
 import { BottomNav } from "./components/BottomNav";
 
@@ -74,8 +74,8 @@ export function AppRouter() {
     <BrowserRouter>
       <ScrollToTop />
       <Routes>
-        <Route path="/" element={<TellyMap />} />
-        <Route path="/home" element={<Index />} />
+        <Route path="/" element={<Index />} />
+        <Route path="/home" element={<Navigate to="/" replace />} />
         <Route path="/debug" element={<IndexDebug />} />
         <Route path="/safe" element={<IndexSafe />} />
         <Route path="/minimal" element={<IndexMinimal />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -33,8 +33,6 @@ export function Navigation({ className }: NavigationProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const isActive = (path: string) => {
-    // /telly-map is also active when on / (the root now renders TellyMap)
-    if (path === '/telly-map' && (location.pathname === '/' || location.pathname === '/telly-map')) return true;
     if (path === location.pathname) return true;
     if (path !== '/' && path !== '/home' && location.pathname.startsWith(path)) return true;
     return false;
@@ -129,15 +127,15 @@ export function Navigation({ className }: NavigationProps) {
           {/* Desktop Right Side */}
           <div className="hidden md:flex items-center gap-3">
 
-            {/* View Mode Toggle — images (/home) ↔ map (/) */}
-            {(location.pathname === '/' || location.pathname === '/telly-map' || location.pathname === '/home') && (
+            {/* View Mode Toggle — images (/) ↔ map (/telly-map) */}
+            {(location.pathname === '/' || location.pathname === '/telly-map') && (
               <div className="inline-flex items-center bg-gray-200 dark:bg-gray-700 rounded-full p-1 gap-1">
-                <Link to="/home">
+                <Link to="/">
                   <Button
                     variant="ghost"
                     size="icon"
                     className={`rounded-full w-9 h-9 transition-all ${
-                      location.pathname === '/home'
+                      location.pathname === '/'
                         ? 'bg-gray-800 hover:bg-gray-900 text-white'
                         : 'hover:bg-gray-300 dark:hover:bg-gray-600'
                     }`}
@@ -146,12 +144,12 @@ export function Navigation({ className }: NavigationProps) {
                     <ImageIcon className="w-4 h-4" />
                   </Button>
                 </Link>
-                <Link to="/">
+                <Link to="/telly-map">
                   <Button
                     variant="ghost"
                     size="icon"
                     className={`rounded-full w-9 h-9 transition-all ${
-                      (location.pathname === '/' || location.pathname === '/telly-map')
+                      location.pathname === '/telly-map'
                         ? 'bg-gray-800 hover:bg-gray-900 text-white'
                         : 'hover:bg-gray-300 dark:hover:bg-gray-600'
                     }`}
@@ -194,15 +192,15 @@ export function Navigation({ className }: NavigationProps) {
 
           {/* Mobile Right Side */}
           <div className="md:hidden flex items-center gap-2">
-            {/* View Mode Toggle — mobile — images (/home) ↔ map (/) */}
-            {(location.pathname === '/' || location.pathname === '/telly-map' || location.pathname === '/home') && (
+            {/* View Mode Toggle — mobile — images (/) ↔ map (/telly-map) */}
+            {(location.pathname === '/' || location.pathname === '/telly-map') && (
               <div className="inline-flex items-center bg-gray-200 dark:bg-gray-700 rounded-full p-1 gap-1">
-                <Link to="/home">
+                <Link to="/">
                   <Button
                     variant="ghost"
                     size="icon"
                     className={`rounded-full w-8 h-8 transition-all ${
-                      location.pathname === '/home'
+                      location.pathname === '/'
                         ? 'bg-gray-800 hover:bg-gray-900 text-white'
                         : 'hover:bg-gray-300 dark:hover:bg-gray-600'
                     }`}
@@ -211,12 +209,12 @@ export function Navigation({ className }: NavigationProps) {
                     <ImageIcon className="w-4 h-4" />
                   </Button>
                 </Link>
-                <Link to="/">
+                <Link to="/telly-map">
                   <Button
                     variant="ghost"
                     size="icon"
                     className={`rounded-full w-8 h-8 transition-all ${
-                      (location.pathname === '/' || location.pathname === '/telly-map')
+                      location.pathname === '/telly-map'
                         ? 'bg-gray-800 hover:bg-gray-900 text-white'
                         : 'hover:bg-gray-300 dark:hover:bg-gray-600'
                     }`}


### PR DESCRIPTION
## Problem

Refreshing the homepage (www.traveltelly.com) lands on the map. Since the Aug 6 "map view as default homepage" change, `/` renders `TellyMap`, so the root URL shows the map (canonical map URL: `/telly-map`) instead of the homepage — bad for refresh behavior, navigation, and SEO.

## Fix

- `/` renders the homepage (`Index`) again — refreshing www.traveltelly.com stays on the homepage
- `/home` redirects to `/` so old links/bookmarks land on the homepage
- `/telly-map` and `/world-map` remain the map's explicit URLs
- Nav: "Map" item is active only on `/telly-map`; the view-mode toggle now switches **images (`/`)** ↔ **map (`/telly-map`)**

## Verification

- `npm test` (tsc + eslint + vitest + vite build) — green
- Built bundle confirmed: `/` → Index, `/telly-map` + `/world-map` → TellyMap, `/home` → redirect to `/`
