### PR TITLE
Fix /reviews: show only real reviews, page past pin-only pages

### DIFF
--- a/src/components/LoadMoreReviewFeed.tsx
+++ b/src/components/LoadMoreReviewFeed.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -267,6 +268,18 @@ export function LoadMoreReviewFeed() {
     })
   ) || [];
 
+  // Auto-advance the first pages while they are full of photo/video pins
+  // (type=pin) and contain no real reviews yet, so the feed reaches the actual
+  // reviews without manual clicks. Bounded to a few pages; beyond that the
+  // Load More button takes over.
+  useEffect(() => {
+    if (isLoading || isLoadingAuth || error) return;
+    if ((allReviews?.length ?? 0) !== 0) return;
+    if (!hasNextPage || isFetchingNextPage) return;
+    if ((data?.pages.length ?? 0) >= 6) return;
+    fetchNextPage();
+  }, [allReviews?.length, hasNextPage, isFetchingNextPage, isLoading, isLoadingAuth, error, data?.pages.length, fetchNextPage]);
+
   if (error) {
     return (
       <Card className="border-dashed">
@@ -293,7 +306,13 @@ export function LoadMoreReviewFeed() {
     );
   }
 
-  if (!allReviews || allReviews.length === 0) {
+  // First pages of the raw kind-34879 stream can be entirely photo/video pins
+  // (type=pin) that carry no real reviews, so the feed starts empty but still
+  // has more pages to fetch. Only show the "no reviews" empty state once every
+  // page has been loaded; otherwise keep the Load More button alive.
+  const hasReviews = (allReviews?.length ?? 0) > 0;
+
+  if (!hasReviews && !hasNextPage) {
     return (
       <Card className="border-dashed">
         <CardContent className="py-12 px-8 text-center">
@@ -315,11 +334,19 @@ export function LoadMoreReviewFeed() {
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {allReviews.map((review) => (
-          <ReviewCard key={review.id} review={review} />
-        ))}
-      </div>
+      {hasReviews && (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {allReviews.map((review) => (
+            <ReviewCard key={review.id} review={review} />
+          ))}
+        </div>
+      )}
+
+      {!hasReviews && hasNextPage && (
+        <p className="text-center text-sm text-muted-foreground">
+          Checking older posts for reviews…
+        </p>
+      )}
 
       {/* Load More Button */}
       {hasNextPage && (

--- a/src/hooks/useInfiniteReviews.test.ts
+++ b/src/hooks/useInfiniteReviews.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { validateReviewEvent } from './useInfiniteReviews';
+
+function reviewEvent(overrides: Partial<NostrEvent> & { tags?: string[][] } = {}): NostrEvent {
+  return {
+    id: 'a'.repeat(64),
+    pubkey: 'b'.repeat(64),
+    kind: 34879,
+    created_at: 1_700_000_000,
+    content: 'Lovely spot, friendly staff.',
+    tags: [
+      ['d', 'sip-space-cafe-bangkok'],
+      ['title', 'Sip Space Cafe'],
+      ['rating', '5'],
+      ['category', 'cafe'],
+      ['g', 'w4g4u4x8'],
+      ['location', 'Bangkok'],
+    ],
+    sig: 'c'.repeat(128),
+    ...overrides,
+  };
+}
+
+describe('validateReviewEvent (kind 34879 feed filter)', () => {
+  it('accepts a real review (d + title + rating + category, no type tag)', () => {
+    expect(validateReviewEvent(reviewEvent())).toBe(true);
+  });
+
+  it('rejects plain map photo/video pins tagged type=pin', () => {
+    const pin = reviewEvent({ tags: [
+      ['d', 'pin-abc123'],
+      ['title', 'Sunset in Koh Samui'],
+      ['rating', '5'],
+      ['category', 'landmarks'],
+      ['type', 'pin'],
+      ['image', 'https://nostr.build/i/abc.jpg'],
+    ] });
+    expect(validateReviewEvent(pin)).toBe(false);
+  });
+
+  it('rejects events that are not kind 34879', () => {
+    expect(validateReviewEvent(reviewEvent({ kind: 1 }))).toBe(false);
+  });
+
+  it('rejects events missing any of d/title/rating/category', () => {
+    const noTitle = reviewEvent({ tags: [['d', 'x'], ['rating', '5'], ['category', 'cafe']] });
+    expect(validateReviewEvent(noTitle)).toBe(false);
+
+    const noRating = reviewEvent({ tags: [['d', 'x'], ['title', 'T'], ['category', 'cafe']] });
+    expect(validateReviewEvent(noRating)).toBe(false);
+
+    const noCategory = reviewEvent({ tags: [['d', 'x'], ['title', 'T'], ['rating', '5']] });
+    expect(validateReviewEvent(noCategory)).toBe(false);
+
+    const noD = reviewEvent({ tags: [['title', 'T'], ['rating', '5'], ['category', 'cafe']] });
+    expect(validateReviewEvent(noD)).toBe(false);
+  });
+
+  it('accepts review events even when they carry other extra tags', () => {
+    const withExtras = reviewEvent({
+      tags: [
+        ['d', 'x'],
+        ['title', 'T'],
+        ['rating', '4'],
+        ['category', 'restaurant'],
+        ['t', 'travel'],
+        ['image', 'https://pics.example/1.jpg'],
+      ],
+    });
+    expect(validateReviewEvent(withExtras)).toBe(true);
+  });
+});

--- a/src/hooks/useInfiniteReviews.ts
+++ b/src/hooks/useInfiniteReviews.ts
@@ -6,7 +6,7 @@ interface ReviewEvent extends NostrEvent {
   kind: 34879;
 }
 
-function validateReviewEvent(event: NostrEvent): event is ReviewEvent {
+export function validateReviewEvent(event: NostrEvent): event is ReviewEvent {
   if (event.kind !== 34879) return false;
 
   const d = event.tags.find(([name]) => name === 'd')?.[1];
@@ -31,14 +31,16 @@ export function useInfiniteReviews() {
     queryFn: async ({ pageParam, signal }) => {
       const abortSignal = AbortSignal.any([signal, AbortSignal.timeout(10000)]);
 
-      // Build filter with pagination
+      // Build filter with pagination. A page of 100 kind-34879 events can be
+      // entirely photo/video pins (type=pin), which are filtered out below, so
+      // a larger limit means fewer round trips to reach the actual reviews.
       const filter: {
         kinds: number[];
         limit: number;
         until?: number;
       } = {
         kinds: [34879],
-        limit: 50, // Load 50 reviews per page
+        limit: 100,
       };
 
       // Add until parameter for pagination (older than this timestamp)
@@ -53,9 +55,13 @@ export function useInfiniteReviews() {
       // Sort by creation time (newest first)
       const sortedReviews = validReviews.sort((a, b) => b.created_at - a.created_at);
 
-      // Get the oldest timestamp for next page
-      const nextPageParam = sortedReviews.length > 0
-        ? sortedReviews[sortedReviews.length - 1].created_at
+      // Advance the cursor on the RAW event stream, not the filtered reviews.
+      // Pins are typically newer than reviews, so a page can contain zero
+      // reviews; if the cursor stopped there the feed would end early and show
+      // "No reviews found" even though older real reviews exist on later pages.
+      // Stop only when a page comes back smaller than the limit (data exhausted).
+      const nextPageParam = events.length >= 100
+        ? Math.min(...events.map((event) => event.created_at))
         : undefined;
 
       return {


### PR DESCRIPTION
## What's broken
`https://www.traveltelly.com/reviews` (GitHub Pages, auto-deploy on merge) shows **"No reviews found yet"** even though 15 real reviews exist. The page also returned HTTP 404 status on direct loads (SPA 404.html fallback — browser rendering still works).

## Root cause
TellyMap publishes every photo/video pin as kind 34879 with a `type=pin` tag, and `/reviews` filters those out client-side. Pins are newer than the reviews, so the infinite feed's pages (50 newest events each) filled up with pins only. When a page filtered down to **zero reviews**, `nextPageParam` became `undefined` → `hasNextPage=false` → pagination stopped. The real reviews sat on older pages that were never reached.

Verified live: page 1 of the raw stream = 50 events, 0 pins-tagged reviews → feed ended before ever seeing the reviews (88–199 days old).

## Fix

- **`src/hooks/useInfiniteReviews.ts`** — advance the page cursor on the raw event stream (min `created_at` of the page) instead of the filtered review list; stop only when a page returns fewer events than the limit. Pin-only pages are now skipped, not terminal. Page limit raised 50 → 100 to cut round trips.
- **`src/components/LoadMoreReviewFeed.tsx`** — the empty state now only shows after every page is loaded; auto-advances up to 6 pages while pages are still pins so reviews appear without clicking, then the Load More button takes over.
- **`src/hooks/useInfiniteReviews.test.ts`** (new) — 5 unit tests pin down the review-only rule (rejects `type=pin`, non-34879 kinds, missing d/title/rating/category; accepts real reviews).

## Validation

- tsc --noEmit: 0 errors · eslint touched files: 0 errors · vitest 20/20 · production build OK
- Live-relay simulation: old logic stopped after page 1 (0 reviews); new logic reaches **all 15 real reviews** (The Chef House in Warsaw, KIBUN COFFEE, …) in 3 pages.

## Note on the 404

GitHub Pages has no SPA rewrite; direct loads of `/reviews`, `/stories`, `/trips` etc. return the app shell with HTTP 404. Recommend Netlify/Vercel hosting to fix the status code, or accept it as-is (page renders in-browser).