### PR TITLE
Homepage opens on the world map; dedupe pinned photos on the grid

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { ScrollToTop } from "./components/ScrollToTop";
 import { BottomNav } from "./components/BottomNav";
 
@@ -74,8 +74,9 @@ export function AppRouter() {
     <BrowserRouter>
       <ScrollToTop />
       <Routes>
-        <Route path="/" element={<Index />} />
-        <Route path="/home" element={<Navigate to="/" replace />} />
+        {/* Homepage = the ONE world map. Images grid lives at /home (toggle). */}
+        <Route path="/" element={<TellyMap />} />
+        <Route path="/home" element={<Index />} />
         <Route path="/debug" element={<IndexDebug />} />
         <Route path="/safe" element={<IndexSafe />} />
         <Route path="/minimal" element={<IndexMinimal />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -33,13 +33,18 @@ export function Navigation({ className }: NavigationProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const isActive = (path: string) => {
+    // The Map nav item represents the ONE world map: highlight on `/` (homepage,
+    // which now IS the map) plus the legacy map URLs.
+    if (path === '/') {
+      return ['/', '/telly-map', '/world-map'].includes(location.pathname);
+    }
     if (path === location.pathname) return true;
     if (path !== '/' && path !== '/home' && location.pathname.startsWith(path)) return true;
     return false;
   };
 
   const allNavItems = [
-    { path: '/telly-map', label: 'Map', icon: Map, color: '#96ae38', hoverColor: '#7d9230' },
+    { path: '/', label: 'Map', icon: Map, color: '#96ae38', hoverColor: '#7d9230' },
     { path: '/reviews', label: 'Reviews', icon: Star, color: '#27b0ff', hoverColor: '#1a9fe6' },
     { path: '/stories', label: 'Stories', icon: BookOpen, color: '#b2d235', hoverColor: '#9dbf2e' },
     { path: '/trips', label: 'Trips', icon: MapPin, color: '#ffcc00', hoverColor: '#e6b800' },
@@ -127,15 +132,15 @@ export function Navigation({ className }: NavigationProps) {
           {/* Desktop Right Side */}
           <div className="hidden md:flex items-center gap-3">
 
-            {/* View Mode Toggle — images (/) ↔ map (/telly-map) */}
-            {(location.pathname === '/' || location.pathname === '/telly-map') && (
+            {/* View Mode Toggle — images (/home) ↔ map (/ = homepage world map) */}
+            {(location.pathname === '/' || location.pathname === '/home') && (
               <div className="inline-flex items-center bg-gray-200 dark:bg-gray-700 rounded-full p-1 gap-1">
-                <Link to="/">
+                <Link to="/home">
                   <Button
                     variant="ghost"
                     size="icon"
                     className={`rounded-full w-9 h-9 transition-all ${
-                      location.pathname === '/'
+                      location.pathname === '/home'
                         ? 'bg-gray-800 hover:bg-gray-900 text-white'
                         : 'hover:bg-gray-300 dark:hover:bg-gray-600'
                     }`}
@@ -144,12 +149,12 @@ export function Navigation({ className }: NavigationProps) {
                     <ImageIcon className="w-4 h-4" />
                   </Button>
                 </Link>
-                <Link to="/telly-map">
+                <Link to="/">
                   <Button
                     variant="ghost"
                     size="icon"
                     className={`rounded-full w-9 h-9 transition-all ${
-                      location.pathname === '/telly-map'
+                      location.pathname === '/'
                         ? 'bg-gray-800 hover:bg-gray-900 text-white'
                         : 'hover:bg-gray-300 dark:hover:bg-gray-600'
                     }`}

--- a/src/hooks/useInfiniteImages.ts
+++ b/src/hooks/useInfiniteImages.ts
@@ -7,6 +7,7 @@ import { useTravelTellyTour } from './useTravelTellyTour';
 import { useAuthorizedReviewers } from './useAuthorizedReviewers';
 import { useAuthorizedMediaUploaders } from './useStockMediaPermissions';
 import { isValidImageUrl } from '@/lib/imageValidation';
+import { dedupeByImage } from '@/lib/dedupeImages';
 
 // Admin pubkey for TravelTelly Tour
 const ADMIN_NPUB = 'npub105em547c5m5gdxslr4fp2f29jav54sxml6cpk6gda7xyvxuzmv6s84a642';
@@ -229,12 +230,16 @@ export function useInfiniteImages() {
       // Sort newest first
       const sortedImages = images.sort((a, b) => b.created_at - a.created_at);
 
+      // Dedupe by image URL: a map pin is auto-listed on /marketplace with the
+      // same photo, so the grid used to show the same thumb twice (pin + market).
+      const dedupedImages = dedupeByImage(sortedImages);
+
       // Cursor for next page: oldest timestamp minus 1
-      const nextPageParam = sortedImages.length > 0
-        ? sortedImages[sortedImages.length - 1].created_at - 1
+      const nextPageParam = dedupedImages.length > 0
+        ? dedupedImages[dedupedImages.length - 1].created_at - 1
         : undefined;
 
-      return { images: sortedImages, nextPageParam };
+      return { images: dedupedImages, nextPageParam };
     },
     getNextPageParam: (lastPage) => lastPage.nextPageParam,
     initialPageParam: undefined as number | undefined,

--- a/src/hooks/useLatestItems.ts
+++ b/src/hooks/useLatestItems.ts
@@ -6,6 +6,7 @@ import { useAuthorizedMediaUploaders } from './useStockMediaPermissions';
 import { nip19 } from 'nostr-tools';
 import { useAdminReviews } from './useAdminReviews';
 import { isValidImageUrl } from '@/lib/imageValidation';
+import { dedupeByImage } from '@/lib/dedupeImages';
 
 // The Traveltelly admin npub
 const ADMIN_NPUB = 'npub105em547c5m5gdxslr4fp2f29jav54sxml6cpk6gda7xyvxuzmv6s84a642';
@@ -868,7 +869,9 @@ export function useCommunityMix() {
         round++;
       }
 
-      return mixed;
+      // Dedupe by image URL: pins are auto-listed on /marketplace with the same
+      // photo, so the mix used to show the same thumb twice (review + stock).
+      return dedupeByImage(mixed);
     },
     staleTime: 3 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/src/lib/dedupeImages.test.ts
+++ b/src/lib/dedupeImages.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { dedupeByImage } from './dedupeImages';
+
+describe('dedupeByImage', () => {
+  test('keeps unique images untouched', () => {
+    const items = [
+      { image: 'https://a/1.jpg', type: 'review' },
+      { image: 'https://a/2.jpg', type: 'story' },
+      { image: 'https://a/3.jpg', type: 'trip' },
+    ];
+    expect(dedupeByImage(items)).toEqual(items);
+  });
+
+  test('drops a marketplace (stock) duplicate when the same photo is also a pin/review', () => {
+    const items = [
+      { image: 'https://a/1.jpg', type: 'stock', title: 'Marketplace' },
+      { image: 'https://a/1.jpg', type: 'review', title: 'Pin' },
+      { image: 'https://a/2.jpg', type: 'stock', title: 'Market only' },
+    ];
+    const out = dedupeByImage(items);
+    // Same photo appears once — as the pin (review), not the marketplace copy.
+    expect(out).toHaveLength(2);
+    expect(out.map(i => i.type)).toEqual(['review', 'stock']);
+  });
+
+  test('pin-first order is stable (first non-stock kept, identical entries collapse)', () => {
+    const items = [
+      { image: 'https://a/1.jpg', type: 'review', title: 'Pin' },
+      { image: 'https://a/1.jpg', type: 'stock', title: 'Marketplace' },
+      { image: 'https://a/1.jpg', type: 'review', title: 'Pin dup' },
+    ];
+    const out = dedupeByImage(items);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual(items[0]);
+  });
+
+  test('two different marketplace products with the same image still collapse to one', () => {
+    const items = [
+      { image: 'https://a/1.jpg', type: 'stock', title: 'A' },
+      { image: 'https://a/1.jpg', type: 'stock', title: 'B' },
+    ];
+    expect(dedupeByImage(items)).toHaveLength(1);
+  });
+});

--- a/src/lib/dedupeImages.ts
+++ b/src/lib/dedupeImages.ts
@@ -1,0 +1,29 @@
+export interface HasImage {
+  image: string;
+  type?: string;
+}
+
+/**
+ * Dedupe a list of thumbnails by image URL, keeping the first occurrence but
+ * preferring a non-marketplace entry when the same photo appears twice.
+ *
+ * Map pins (kind 34879) are auto-listed on /marketplace (kind 30402) with the
+ * SAME image URL, so the homepage grid used to show the same photo twice —
+ * once as the pin thumb and once as the marketplace thumb. `stock` is the
+ * marketplace type; when a duplicate image is found and one entry is a
+ * marketplace product, the non-marketplace one wins (the pin thumb stays).
+ */
+export function dedupeByImage<T extends HasImage>(items: T[]): T[] {
+  const byImage = new Map<string, T>();
+  for (const item of items) {
+    const existing = byImage.get(item.image);
+    if (!existing) {
+      byImage.set(item.image, item);
+      continue;
+    }
+    if (existing.type === 'stock' && item.type !== 'stock') {
+      byImage.set(item.image, item);
+    }
+  }
+  return Array.from(byImage.values());
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,6 +19,7 @@ import { VideoThumbnailGrid, VideoItem } from "@/components/VideoThumbnailGrid";
 import { useInfiniteImages } from "@/hooks/useInfiniteImages";
 
 import { useViewMode } from "@/contexts/ViewModeContext";
+import { dedupeByImage } from "@/lib/dedupeImages";
 import { MapPin, Star, Camera, Zap, BookOpen, ArrowRight, Globe, Video } from "lucide-react";;
 import { Link } from "react-router-dom";
 
@@ -123,7 +124,16 @@ const Index = ({ initialLocation }: IndexProps = {}) => {
   } = useInfiniteImages();
 
   // Flatten all pages of images into a single array
-  const allImages = infiniteImagesData?.pages.flatMap(page => page.images) || [];
+  const allImages = dedupeByImage(infiniteImagesData?.pages.flatMap(page => page.images) || []);
+
+  // A map pin is auto-listed on /marketplace with the same photo — a marketplace
+  // thumb whose image is already shown in the grid above is the same photo, so
+  // only show it in the Stock section when the grid doesn't already show it.
+  const gridShownImages = new Set<string>([
+    ...communityMix.map(c => c.image),
+    ...allImages.map(i => i.image),
+  ]);
+  const stockMediaToShow = latestStockMediaItems.filter(m => m.image && !gridShownImages.has(m.image));
 
   // Show first page immediately; auto-load more as user scrolls
   const THUMBNAIL_BATCH = 24;
@@ -463,7 +473,7 @@ const Index = ({ initialLocation }: IndexProps = {}) => {
 
                 {/* Stock Media Section — lazy */}
                 <div ref={stockSentinel} />
-                {(stockVisible && latestStockMediaItems.length > 0) && (
+                {(stockVisible && stockMediaToShow.length > 0) && (
                   <div className="mb-6 md:mb-12">
                     <div className="flex justify-between items-center mb-3">
                       <h2 className="text-lg md:text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
@@ -480,7 +490,7 @@ const Index = ({ initialLocation }: IndexProps = {}) => {
                       </Link>
                     </div>
                     <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 gap-0.5 md:gap-1">
-                      {latestStockMediaItems.map((media, index) => (
+                      {stockMediaToShow.map((media, index) => (
                         <Link key={media.naddr} to={`/media/preview/${media.naddr}`}>
                           <div className="relative aspect-square overflow-hidden group cursor-pointer bg-gray-200 dark:bg-gray-700">
                             <FastThumbnail src={media.image!} alt={media.title} priority={index === 0} className="transition-transform duration-300 group-hover:scale-105" />


### PR DESCRIPTION
Fixes two homepage issues reported by BitPopArt:

1. www.traveltelly.com now opens on the ONE world map (/ renders TellyMap) instead of the images grid. The grid view moved to /home; the nav Images <-> Map toggle switches between them. Map nav item highlights on /, /telly-map and /world-map.

2. No more double thumbnails: every map pin is auto-listed on /marketplace as a kind-30402 product sharing the same photo, so the homepage grid showed the same image twice (pin + marketplace). New dedupeByImage() keeps one thumb per photo URL (the non-marketplace entry wins) and it is applied to the images grid, the community mix and the Stock Media section (which now only shows products not already shown in the grid).

Verified: tsc, eslint, vitest 24/24 (incl 4 new dedupe tests), prod build.