### PR TITLE
Fix TS 5.8 digest typing error that fails CI test job

### DIFF
--- a/src/lib/lnPaymentProof.ts
+++ b/src/lib/lnPaymentProof.ts
@@ -27,7 +27,9 @@ function hexToBytes(hex: string): Uint8Array | null {
 }
 
 async function sha256Hex(data: Uint8Array): Promise<string> {
-  const digest = await crypto.subtle.digest('SHA-256', data);
+  // `data` is always a fresh Uint8Array from hexToBytes (never a view into a
+  // shared buffer), so the cast is sound — matches apkCertExtractor.ts.
+  const digest = await crypto.subtle.digest('SHA-256', data as Uint8Array<ArrayBuffer>);
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');


### PR DESCRIPTION
Fixes the red test check that has failed on every PR since the TS 5.8 upgrade: tsc --noEmit exits 2 on src/lib/lnPaymentProof.ts:30 (Uint8Array<ArrayBufferLike> not assignable to BufferSource). Cast to Uint8Array<ArrayBuffer> following the repo pattern in apkCertExtractor.ts.

Verified locally: npm run test (tsc + eslint + vitest 24/24 + prod build) green.