### PR TITLE
fix: keep the site menu on /telly-map — stop serving the raw full-frame map

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,12 +73,13 @@ export default tseslint.config(
     },
   },
   {
-    files: ["public/telly-map.html"],
-    // telly-map.html is a standalone 3 MB static page that is NOT built by Vite.
-    // Its inline scripts are integral to the page (embedded geometry data + the
-    // map runtime). Extracting them to external files risks breaking the deployed
-    // map for zero functional benefit, so the inline-script rule is scoped out
-    // for this one file only. All other HTML lint rules still apply.
+    files: ["public/telly-map-frame.html"],
+    // telly-map-frame.html (formerly telly-map.html) is a standalone 3 MB static
+    // map page that is NOT built by Vite. Its inline scripts are integral to the
+    // page (embedded geometry data + the map runtime). Extracting them to
+    // external files risks breaking the deployed map for zero functional benefit,
+    // so the inline-script rule is scoped out for this one file only. All other
+    // HTML lint rules still apply.
     rules: {
       "custom/no-inline-script": "off",
     },

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,8 +4,8 @@
   functions = "netlify/functions"
 
 [[redirects]]
-  from = "/telly-map.html"
-  to = "/telly-map.html"
+  from = "/telly-map-frame.html"
+  to = "/telly-map-frame.html"
   status = 200
 
 [[redirects]]

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -10,7 +10,7 @@
   RewriteEngine On
   RewriteBase /
   RewriteRule ^index\.html$ - [L]
-  RewriteRule ^telly-map\.html$ - [L]
+  RewriteRule ^telly-map-frame.html$ - [L]
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
   RewriteRule . /index.html [L]

--- a/public/_headers
+++ b/public/_headers
@@ -3,7 +3,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
 
-/telly-map.html
+/telly-map-frame.html
   X-Frame-Options: SAMEORIGIN
   Content-Security-Policy: frame-ancestors 'self'
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/telly-map.html /telly-map.html 200
+/telly-map-frame.html /telly-map-frame.html 200
 /* /index.html 200

--- a/public/telly-map-frame.html
+++ b/public/telly-map-frame.html
@@ -1786,7 +1786,7 @@ async function renderLocInfo(p, forcedPlace){
 
 /* ═════════ focus: open the map at a /<location> view ═════════ */
 /*
- * The map supports ?focus=<name> (e.g. /telly-map.html?focus=Friesland,
+ * The map supports ?focus=<name> (e.g. /telly-map-frame.html?focus=Friesland,
  * used by the /friesland location pages). Resolves the name to
  * coordinates (embedded city list first, Nominatim search as fallback),
  * flies there, and shows a small chip with a ✕ to return to world view.

--- a/src/pages/LocationPage.tsx
+++ b/src/pages/LocationPage.tsx
@@ -14,7 +14,7 @@ const RESERVED_ROUTES = [
   'marketplace', 'media', 'download', 'category-test', 'stock-media-permissions',
   'media-management', 'map-marker-editor', 'events', 'search-test',
   'simple-map-demo', 'what-is-nostr', 'category-migration',
-  'home', 'telly-map', 'world-map', 'telly-map.html'
+  'home', 'telly-map', 'world-map', 'telly-map.html', 'telly-map-frame', 'telly-map-frame.html'
 ];
 
 export function LocationPage() {

--- a/src/pages/TellyMap.tsx
+++ b/src/pages/TellyMap.tsx
@@ -5,11 +5,13 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useReviewPermissions } from '@/hooks/useReviewPermissions';
 
 /**
- * TellyMap — full-screen personal travel photo-pin map.
+ * TellyMap — the ONE world map, shown always beneath the standard Traveltelly
+ * navigation so the site menu is never lost.
  *
- * The telly-map.html has its own branded header (TellyMap · by traveltelly)
- * with a home link, so no React nav is shown here. The page takes the full
- * viewport.
+ * The standalone map markup lives in /telly-map-frame.html and is embedded here
+ * in an <iframe> below the nav. (Renamed from telly-map.html on 2026-08-16 so
+ * that the /telly-map route resolves through the React SPA instead of GitHub
+ * Pages extensionless-serving the raw full-frame file — which hid the menu.)
  *
  * Permissions: after the iframe loads, we postMessage the user's pubkey and
  * canAddPins flag so the map gates the "+ Add pins" button behind the same
@@ -76,7 +78,7 @@ export default function TellyMap() {
       <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
         <iframe
           ref={iframeRef}
-          src="/telly-map.html"
+          src="/telly-map-frame.html"
           title="TellyMap – your personal travel photo map"
           style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 'none' }}
           allow="geolocation; camera"


### PR DESCRIPTION
## Problem\n@BitPopArt: "never show telly-map full frame; always the site and the world map under the menu, so we never lose the menu."\n\n## Root cause\nThe site deploys to **GitHub Pages**. A physical static file `dist/telly-map.html` (the standalone full-frame map with its own topbar and NO site nav) made GitHub Pages extensionless-serve `/telly-map` straight from that raw file (HTTP 200) — bypassing the React SPA entirely, so the Traveltelly menu never rendered. `/` and `/world-map` had no colliding static file, so they correctly fell through to the SPA and showed the menu + map.\n\n## Fix\nRenamed the standalone map asset to `public/telly-map-frame.html`, embedded via iframe under the standard `Navigation`, so `/telly-map` now resolves through the React SPA like `/world-map` — always keeping the site menu with the world map beneath it. Updated the iframe src, `LocationPage` reserved routes, and the netlify/`_redirects`/`_headers`/`.htaccess` references.\n\n## Verified\ntsc 0, eslint 0, vitest 24/24, prod build green.