### PR TITLE
fix: map tag 'Barcelona' flies to the wrong city (Venezuela, not Spain)

### DIFF
--- a/public/telly-map-frame.html
+++ b/public/telly-map-frame.html
@@ -1793,11 +1793,19 @@ async function renderLocInfo(p, forcedPlace){
  */
 async function resolveFocusName(name){
  const want = (name||'').toLowerCase().trim().replace(/\s+/g,' ');
- // 1) cities bundled into the page
+ // 1) cities bundled into the page. Several cities can share one name
+ //    (Barcelona ES vs Barcelona VE, Santiago CL vs Santiago DO, ...):
+ //    rank 0 = globally important city, 7 = smallest tier — always pick
+ //    the most important match so the famous city wins (e.g. Barcelona,
+ //    Spain flies there, not Barcelona, Venezuela).
+ let best = null;
  for(const c of CITIES){
   if((c[3]||'').toLowerCase().trim().replace(/\s+/g,' ') === want){
-   return {lat: c[1], lon: c[0], zoom: Math.min(13, 9 + Math.max(0, 2 - c[2]))};
+   if(!best || c[2] < best[2]) best = c;
   }
+ }
+ if(best){
+  return {lat: best[1], lon: best[0], zoom: Math.min(13, 9 + Math.max(0, 2 - best[2]))};
  }
  // 2) Nominatim search (countries, provinces, towns)
  try{


### PR DESCRIPTION
BitPopArt: clicking a Barcelona thumb then the 'barcelona' tag shows no thumbs on the map in/around Barcelona.

Root cause: resolveFocusName() returned the FIRST exact city-name match in the bundled CITIES index. Two cities are named exactly "Barcelona": Barcelona, Venezuela (rank 7, lat 10.13 / lon -64.72) sorts before Barcelona, Spain (rank 2, lat 41.385 / lon 2.181) — so the tag flew the map to the Caribbean instead of Spain. 129 duplicate city names exist in the index, so any colliding name whose famous city was not first in the array was affected.

Fix: among exact name matches pick the smallest rank (0 = world's leading cities, 7 = smallest tier). Barcelona (Spain) now wins; every other duplicate name also prefers its most prominent city. The same resolver backs ?focus=<name>, so location deep links benefit too.

Verified headless-Chrome against the patched file: resolveFocusName('Barcelona') -> {lat:41.385, lon:2.181, zoom:9}; thumb click -> tag click -> map centers Barcelona ES, 10 pins clustered. Before: center {lat:10.13, lng:-64.72}, nothing visible. tsc 0, vitest 24/24, prod build green.