### PR TITLE
fix: move TravelTelly help bot icon to bottom-left

### DIFF
--- a/src/components/HelpBot.tsx
+++ b/src/components/HelpBot.tsx
@@ -51,7 +51,7 @@ export function HelpBot() {
       {/* Floating Help Button */}
       <Button
         onClick={() => setIsOpen(true)}
-        className="fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg z-50 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
+        className="fixed bottom-6 left-6 h-14 w-14 rounded-full shadow-lg z-50 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
         size="icon"
         aria-label="Get help"
       >


### PR DESCRIPTION
Moves the floating TravelTelly help bot button from bottom-right to bottom-left so it no longer covers the worldmap leaflet zoom in/out control (bottomright in /telly-map-frame.html).