### PR TITLE
feat: Social Media Planner - post site media to Nostr, X, Facebook, Instagram

### DIFF
--- a/SOCIAL_MEDIA_PLANNER.md
+++ b/SOCIAL_MEDIA_PLANNER.md
@@ -1,0 +1,46 @@
+# Social Media Planner
+
+Admin Panel → **Social Media Planner** (`/admin/share-scheduler`).
+
+Submit TravelTelly media (reviews, stories/videos, trips, stock products) from
+the site to your social channels:
+
+- **Nostr** — instantly and fully working (signed kind-1 notes via the
+  site's connected Nostr account; scheduling supported).
+- **X (Twitter)** — instant posting via the `/api/social-publish` Netlify
+  function (OAuth 1.0a, media upload + POST /2/tweets).
+- **Facebook** — photo/message posts to your Page via the Graph API.
+- **Instagram** — instant posts via the Content Publishing API (Business
+  account required; Meta only allows *scheduled* posts for partners, so
+  posting is instant-only, the queue below works as a reminder list).
+
+## How to use
+
+1. Open **Admin Panel → Social Media Planner** (admin account only).
+2. In any platform tab, use **Pick media from the site** to fill the form with
+   an existing review/story/trip/stock product, or paste a TravelTelly URL and
+   auto-fill.
+3. Edit the text/hashtags, then either:
+   - **Post now** (needs the backend configured — see below), or
+   - schedule it, or use **Copy text / Open composer** to post manually with
+     the text pre-filled.
+
+## Enabling live posting (X / Facebook / Instagram)
+
+The keys never live in the browser. Set these in **Netlify → Site →
+Environment variables** (this repo deploys via `netlify.toml`; the function is
+`netlify/functions/social-publish.mjs`, endpoint `/api/social-publish`):
+
+| Platform | Env vars | Where to get them |
+|----------|----------|-------------------|
+| X | `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` | developer.x.com → Project → Keys & tokens (Read & Write) |
+| Facebook | `FB_PAGE_ID`, `FB_PAGE_ACCESS_TOKEN` | developers.facebook.com → Meta app → Graph API Explorer (pages_manage_posts) |
+| Instagram | `IG_BUSINESS_ID`, `FB_PAGE_ACCESS_TOKEN` | Same Meta app; IG account must be Business linked to the page (instagram_basic + instagram_content_publish) |
+
+Status checks: `GET /api/social-publish` returns booleans per platform; the
+planner shows a green **Ready to post** badge once configured.
+
+> The live site currently runs on GitHub Pages, which cannot run Netlify
+> functions. Until the Netlify site for this repo is deployed again, the
+> planner shows "backend offline" and you can still publish via the composer
+> shortcut buttons. Nostr publishing is unaffected.

--- a/netlify/functions/social-publish.mjs
+++ b/netlify/functions/social-publish.mjs
@@ -1,0 +1,316 @@
+/**
+ * Social Media Planner — publish endpoint (Netlify Function).
+ *
+ * The Admin Panel "Social Media Planner" calls this to post TravelTelly media
+ * out to X (Twitter), Facebook and Instagram. Platform credentials are secrets
+ * that live ONLY in the server environment (Netlify env vars) — never in the
+ * browser bundle.
+ *
+ * Endpoints:
+ *   GET  /api/social-publish            → { backendOnline, x, facebook, instagram }
+ *                                       (booleans only — no secrets ever leak)
+ *   POST /api/social-publish            → { ok } and platform result
+ *      body: { platform: 'x'|'facebook'|'instagram', text, imageUrl?, url? }
+ *
+ * Required env vars (set in Netlify → Site → Environment variables):
+ *   X (Twitter):  X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_TOKEN_SECRET
+ *                 (Create: https://developer.x.com → Project → "Keys and tokens" →
+ *                  Read and Write app permissions, OAuth 1.0a tokens)
+ *   Facebook:     FB_PAGE_ID, FB_PAGE_ACCESS_TOKEN
+ *                 (Create a Meta app: https://developers.facebook.com → App →
+ *                  add "Facebook Login"/"Pages" product → get a long-lived
+ *                  Page Access Token via the Graph API Explorer with the
+ *                  pages_manage_posts permission)
+ *   Instagram:    IG_BUSINESS_ID, reuse FB_PAGE_ACCESS_TOKEN
+ *                 (IG must be a Business/Professional account linked to the
+ *                  FB page; token needs instagram_basic +
+ *                  instagram_content_publish)
+ *
+ * Notes / platform constraints:
+ *   - X uses OAuth 1.0a (HMAC-SHA1) with the v1.1 chunked media upload +
+ *     POST /2/tweets.
+ *   - Facebook posts a photo (with message) or a plain message.
+ *   - Instagram publishes instantly via the Content Publishing API. Meta only
+ *     allows *scheduled* posts for partner-whitelisted apps, so "post now" is
+ *     the supported mode.
+ *   - The image is fetched server-side from imageUrl and re-hosted as X media /
+ *     referenced by URL for FB & IG — the client never handles tokens.
+ */
+export const config = { path: '/api/social-publish' };
+
+import crypto from 'node:crypto';
+
+const X_UPLOAD = 'https://upload.twitter.com/1.1/media/upload.json';
+const X_TWEETS = 'https://api.x.com/2/tweets';
+const FB_BASE = 'https://graph.facebook.com/v21.0';
+const MAX_CHUNK = 5 * 1024 * 1024; // X media APPEND chunk size (5 MiB)
+
+// ---------------------------------------------------------------------------
+// Small JSON + CORS helpers (same style as create-payment-intent.mjs)
+// ---------------------------------------------------------------------------
+
+function json(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}
+
+function fail(status, error) {
+  return json(status, { ok: false, error });
+}
+
+function qs(params) {
+  const usp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null) usp.set(k, String(v));
+  }
+  return usp.toString();
+}
+
+async function fbGraphPost(path, params) {
+  const url = `${FB_BASE}${path}?${qs(params)}`;
+  const res = await fetch(url, { method: 'POST', headers: { Accept: 'application/json' } });
+  const data = await res.json().catch(() => null);
+  if (!res.ok || !data || data.error) {
+    const msg = data && data.error && data.error.message
+      ? `Meta API ${res.status}: ${data.error.message}`
+      : `Meta API error (HTTP ${res.status})`;
+    throw new Error(msg);
+  }
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// X (Twitter) — OAuth 1.0a HMAC-SHA1
+// ---------------------------------------------------------------------------
+
+function rfc3986(str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, (c) =>
+    '%' + c.charCodeAt(0).toString(16).toUpperCase(),
+  );
+}
+
+function oauthHeader(method, url, params, creds) {
+  const oauth = {
+    oauth_consumer_key: creds.consumerKey,
+    oauth_nonce: crypto.randomBytes(16).toString('hex'),
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+    oauth_token: creds.token,
+    oauth_version: '1.0',
+  };
+  const all = { ...oauth, ...params };
+  const base = Object.keys(all)
+    .sort()
+    .map((k) => `${rfc3986(k)}=${rfc3986(all[k])}`)
+    .join('&');
+  const signatureBase = `${method}&${rfc3986(url)}&${rfc3986(base)}`;
+  const key = `${rfc3986(creds.consumerSecret)}&${rfc3986(creds.tokenSecret)}`;
+  oauth.oauth_signature = crypto.createHmac('sha1', key).update(signatureBase).digest('base64');
+  return (
+    'OAuth ' +
+    Object.entries(oauth)
+      .map(([k, v]) => `${rfc3986(k)}="${rfc3986(v)}"`)
+      .join(', ')
+  );
+}
+
+async function xFetch(method, urlString, creds, params, body, contentType) {
+  const res = await fetch(urlString, {
+    method,
+    headers: {
+      Authorization: oauthHeader(method, urlString.split('?')[0], params, creds),
+      ...(contentType ? { 'Content-Type': contentType } : {}),
+      Accept: 'application/json',
+    },
+    body,
+  });
+  const text = await res.text();
+  let data = null;
+  try { data = JSON.parse(text); } catch { data = null; }
+  if (!res.ok) {
+    const twitterErr = data && data.errors && data.errors[0]
+      ? `${data.errors[0].code}: ${data.errors[0].message}`
+      : data && data.detail
+        ? data.detail
+        : `X API error (HTTP ${res.status})`;
+    throw new Error(`X (Twitter) ${twitterErr}`);
+  }
+  return data;
+}
+
+async function xUploadMedia(imageUrl, creds) {
+  const res = await fetch(imageUrl, { signal: AbortSignal.timeout(60000) });
+  if (!res.ok) throw new Error(`Downloading image failed (HTTP ${res.status})`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  const total = buf.length;
+
+  // Detect a sensible media type from the URL, default JPEG.
+  const cleanUrl = imageUrl.split('?')[0].toLowerCase();
+  const mediaType = cleanUrl.endsWith('.png') ? 'image/png'
+    : cleanUrl.endsWith('.gif') ? 'image/gif'
+    : cleanUrl.endsWith('.webp') ? 'image/webp'
+    : 'image/jpeg';
+
+  // 1) INIT
+  const initParams = { command: 'INIT', media_type: mediaType, total_bytes: total };
+  const initUrl = `${X_UPLOAD}?${qs(initParams)}`;
+  const init = await xFetch('POST', initUrl, creds, initParams, undefined, undefined);
+  const mediaId = String(init.media_id_string || init.media_id);
+  if (!mediaId) throw new Error('X upload INIT failed (no media_id)');
+
+  // 2) APPEND in ≤5 MiB chunks (raw binary body, params signed in URL)
+  for (let index = 0, offset = 0; offset < total; index++, offset += MAX_CHUNK) {
+    const chunk = buf.subarray(offset, Math.min(offset + MAX_CHUNK, total));
+    const params = { command: 'APPEND', media_id: mediaId, segment_index: index };
+    const url = `${X_UPLOAD}?${qs(params)}`;
+    await xFetch('POST', url, creds, params, chunk, 'application/octet-stream');
+  }
+
+  // 3) FINALIZE (and wait out processing if the API asks us to)
+  const finParams = { command: 'FINALIZE', media_id: mediaId };
+  let fin = await xFetch('POST', `${X_UPLOAD}?${qs(finParams)}`, creds, finParams, undefined, undefined);
+  for (let i = 0; i < 5 && fin && fin.processing_info && fin.processing_info.state === 'pending'; i++) {
+    const wait = Math.min((fin.processing_info.check_after_secs || 2) * 1000, 10000);
+    await new Promise((r) => setTimeout(r, wait));
+    const statusParams = { command: 'STATUS', media_id: mediaId };
+    fin = await xFetch('POST', `${X_UPLOAD}?${qs(statusParams)}`, creds, statusParams, undefined, undefined);
+  }
+  if (fin && fin.processing_info && fin.processing_info.state === 'failed') {
+    throw new Error('X upload processing failed');
+  }
+  return String(mediaId);
+}
+
+async function publishX(body) {
+  const creds = {
+    consumerKey: process.env.X_API_KEY,
+    consumerSecret: process.env.X_API_SECRET,
+    token: process.env.X_ACCESS_TOKEN,
+    tokenSecret: process.env.X_ACCESS_TOKEN_SECRET,
+  };
+  if (!creds.consumerKey || !creds.consumerSecret || !creds.token || !creds.tokenSecret) {
+    throw new Error('X is not configured (missing X_API_KEY / X_API_SECRET / X_ACCESS_TOKEN / X_ACCESS_TOKEN_SECRET)');
+  }
+
+  const text = (body.text || '').trim();
+  const mediaIds = [];
+  if (body.imageUrl) {
+    const id = await xUploadMedia(body.imageUrl, creds);
+    mediaIds.push(id);
+  }
+
+  const payload = { text };
+  if (mediaIds.length) payload.media = { media_ids: mediaIds };
+
+  const created = await xFetch('POST', X_TWEETS, creds, {}, JSON.stringify(payload), 'application/json');
+  const tweetId = created && (created.data && created.data.id);
+  return {
+    ok: true,
+    platform: 'x',
+    id: tweetId || null,
+    url: tweetId ? `https://twitter.com/i/status/${tweetId}` : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Facebook — Graph API (photo post or message post)
+// ---------------------------------------------------------------------------
+
+async function publishFacebook(body) {
+  const pageId = process.env.FB_PAGE_ID;
+  const token = process.env.FB_PAGE_ACCESS_TOKEN;
+  if (!pageId || !token) {
+    throw new Error('Facebook is not configured (missing FB_PAGE_ID / FB_PAGE_ACCESS_TOKEN)');
+  }
+  const text = (body.text || '').trim();
+  if (!text) throw new Error('Facebook post needs text');
+
+  if (body.imageUrl) {
+    const data = await fbGraphPost(`/${pageId}/photos`, {
+      url: body.imageUrl,
+      message: text,
+      access_token: token,
+    });
+    return { ok: true, platform: 'facebook', id: data.id || null };
+  }
+  const data = await fbGraphPost(`/${pageId}/feed`, { message: text, access_token: token });
+  return { ok: true, platform: 'facebook', id: data.id || null };
+}
+
+// ---------------------------------------------------------------------------
+// Instagram — Content Publishing API (instant)
+// ---------------------------------------------------------------------------
+
+async function publishInstagram(body) {
+  const igId = process.env.IG_BUSINESS_ID;
+  const token = process.env.FB_PAGE_ACCESS_TOKEN;
+  if (!igId || !token) {
+    throw new Error('Instagram is not configured (missing IG_BUSINESS_ID / FB_PAGE_ACCESS_TOKEN)');
+  }
+  const text = (body.text || '').trim();
+  if (!body.imageUrl) throw new Error('Instagram posts need a media image (imageUrl)');
+  if (!text) throw new Error('Instagram post caption is required');
+
+  const container = await fbGraphPost(`/${igId}/media`, {
+    caption: text,
+    image_url: body.imageUrl,
+    access_token: token,
+  });
+  if (!container.id) throw new Error('Instagram container creation failed');
+
+  const published = await fbGraphPost(`/${igId}/media_publish`, {
+    creation_id: container.id,
+    access_token: token,
+  });
+
+  return {
+    ok: true,
+    platform: 'instagram',
+    id: published.id || container.id || null,
+    url: published.permalink || null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export default async function handler(req) {
+  const url = new URL(req.url);
+
+  if (req.method === 'OPTIONS') return json(200, { ok: true });
+  if (req.method === 'GET') {
+    return json(200, {
+      backendOnline: true,
+      x: !!(process.env.X_API_KEY && process.env.X_API_SECRET && process.env.X_ACCESS_TOKEN && process.env.X_ACCESS_TOKEN_SECRET),
+      facebook: !!(process.env.FB_PAGE_ID && process.env.FB_PAGE_ACCESS_TOKEN),
+      instagram: !!(process.env.IG_BUSINESS_ID && process.env.FB_PAGE_ACCESS_TOKEN),
+    });
+  }
+  if (req.method !== 'POST') return json(405, { ok: false, error: 'Method not allowed' });
+
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return json(400, { ok: false, error: 'Invalid JSON body' });
+  }
+
+  try {
+    switch (body.platform) {
+      case 'x': return json(200, await publishX(body));
+      case 'facebook': return json(200, await publishFacebook(body));
+      case 'instagram': return json(200, await publishInstagram(body));
+      default: return json(400, { ok: false, error: `Unknown platform: ${body.platform}` });
+    }
+  } catch (err) {
+    return json(500, { ok: false, error: err && err.message ? err.message : 'Publish failed' });
+  }
+}

--- a/src/components/PlannerMediaPicker.tsx
+++ b/src/components/PlannerMediaPicker.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ImageOff, Loader2, Star, BookOpen, MapPin, Camera } from 'lucide-react';
+import { usePlannerMedia, type PlannerCategory, type PlannerMediaItem } from '@/hooks/usePlannerMedia';
+
+const CATEGORY_TABS: { key: PlannerCategory; label: string; icon: typeof Star }[] = [
+  { key: 'reviews', label: 'Reviews', icon: Star },
+  { key: 'stories', label: 'Stories', icon: BookOpen },
+  { key: 'trips', label: 'Trips', icon: MapPin },
+  { key: 'stock', label: 'Stock Media', icon: Camera },
+];
+
+interface PlannerMediaPickerProps {
+  onPick: (item: PlannerMediaItem) => void;
+}
+
+/**
+ * "Pick media from the site" — the picker at the top of the Social Media
+ * Planner forms. Shows the latest published TravelTelly content from the
+ * relay (reviews, stories, trips, stock products). Clicking a thumbnail fills
+ * the planner form (URL, title, image, hashtags) for whichever platform tab
+ * is active so the post can be scheduled or published with one click.
+ */
+export function PlannerMediaPicker({ onPick }: PlannerMediaPickerProps) {
+  const { data: items, isLoading } = usePlannerMedia();
+  const [category, setCategory] = useState<PlannerCategory>('reviews');
+
+  const visible = (items || []).filter((item) => item.category === category);
+
+  return (
+    <Card className="border-dashed">
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle className="text-base flex items-center gap-2">
+              📤 Pick media from the site
+            </CardTitle>
+            <CardDescription>
+              Choose published content to fill this post — edit it afterwards if you like.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {CATEGORY_TABS.map(({ key, label, icon: Icon }) => (
+              <Button
+                key={key}
+                type="button"
+                size="sm"
+                variant={category === key ? 'default' : 'outline'}
+                className={category === key ? 'bg-purple-600 hover:bg-purple-700' : ''}
+                onClick={() => setCategory(key)}
+              >
+                <Icon className="w-3.5 h-3.5 mr-1.5" />
+                {label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-6 text-muted-foreground text-sm">
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            Loading latest {CATEGORY_TABS.find((t) => t.key === category)?.label.toLowerCase()}…
+          </div>
+        ) : (items || []).length === 0 ? (
+          <div className="flex items-center justify-center gap-2 py-6 text-muted-foreground text-sm">
+            <ImageOff className="w-4 h-4" />
+            No published content found yet.
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2">
+            {visible.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => onPick(item)}
+                className="group relative aspect-square overflow-hidden rounded-lg border bg-muted text-left hover:ring-2 hover:ring-purple-500 transition"
+                title={item.title}
+              >
+                <img
+                  src={item.image}
+                  alt={item.title}
+                  loading="lazy"
+                  className="h-full w-full object-cover transition group-hover:scale-105"
+                />
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-2 pt-6 pb-1">
+                  <div className="line-clamp-1 text-[11px] font-medium text-white">{item.title}</div>
+                </div>
+                {item.hashtags.length > 0 && (
+                  <Badge variant="secondary" className="absolute top-1 right-1 bg-black/60 text-white text-[9px]">
+                    #{item.hashtags[0]}
+                  </Badge>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/usePlannerMedia.ts
+++ b/src/hooks/usePlannerMedia.ts
@@ -1,0 +1,113 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNostr } from '@nostrify/react';
+import { nip19 } from 'nostr-tools';
+import { isValidImageUrl } from '@/lib/imageValidation';
+
+// The Traveltelly admin npub (owner-authored stories/trips)
+const ADMIN_NPUB = 'npub105em547c5m5gdxslr4fp2f29jav54sxml6cpk6gda7xyvxuzmv6s84a642';
+const ADMIN_HEX = nip19.decode(ADMIN_NPUB).data as string;
+
+export type PlannerCategory = 'reviews' | 'stories' | 'trips' | 'stock';
+
+export interface PlannerMediaItem {
+  id: string;
+  category: PlannerCategory;
+  url: string;
+  title: string;
+  image: string;
+  hashtags: string[];
+}
+
+const CATEGORY_ROUTE: Record<number, { category: PlannerCategory; route: string }> = {
+  34879: { category: 'reviews', route: 'review' },
+  30023: { category: 'stories', route: 'story' },
+  34235: { category: 'stories', route: 'video' },
+  34236: { category: 'stories', route: 'video' },
+  30025: { category: 'trips', route: 'trip' },
+  30402: { category: 'stock', route: 'media/preview' },
+};
+
+/** Pull an image URL out of an event the same way the rest of the site does. */
+function extractImage(event: { kind: number; tags: string[][] }): string {
+  const find = (name: string) => event.tags.find(([tagName]) => tagName === name)?.[1] || '';
+  if (event.kind === 34235 || event.kind === 34236) {
+    const imeta = event.tags.find(([name]) => name === 'imeta');
+    if (imeta) {
+      for (let i = 1; i < imeta.length; i++) {
+        if (imeta[i].startsWith('image ')) return imeta[i].substring(6);
+      }
+    }
+    return find('thumb') || find('image');
+  }
+  return find('image');
+}
+
+function buildItem(
+  event: { id: string; kind: number; pubkey: string; created_at: number; tags: string[][] },
+  identifier: string,
+  title: string,
+  image: string,
+): PlannerMediaItem | null {
+  const meta = CATEGORY_ROUTE[event.kind];
+  if (!meta || !identifier || !title || !isValidImageUrl(image)) return null;
+
+  const naddr = nip19.naddrEncode({
+    identifier,
+    pubkey: event.pubkey,
+    kind: event.kind,
+  });
+
+  const hashtags = event.tags
+    .filter(([name]) => name === 't')
+    .map(([, value]) => value)
+    .filter((tag): tag is string => Boolean(tag) && !['travel', 'traveltelly'].includes(tag.toLowerCase()))
+    .slice(0, 4);
+
+  return {
+    id: event.id,
+    category: meta.category,
+    url: `/${meta.route}/${naddr}`,
+    title,
+    image,
+    hashtags,
+  };
+}
+
+/**
+ * Latest publisher-ready TravelTelly media (reviews, stories/videos, trips,
+ * stock products) straight from the relay — used by the Social Media Planner
+ * picker to submit existing site content to Nostr / X / Facebook / Instagram.
+ */
+export function usePlannerMedia() {
+  const { nostr } = useNostr();
+
+  return useQuery<PlannerMediaItem[]>({
+    queryKey: ['planner-media'],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(10000)]);
+      const events = await nostr.query([
+        { kinds: [34879], limit: 8 },
+        { kinds: [30023], authors: [ADMIN_HEX], limit: 6 },
+        { kinds: [34235, 34236], authors: [ADMIN_HEX], limit: 6 },
+        { kinds: [30025], authors: [ADMIN_HEX], limit: 6 },
+        { kinds: [30402], limit: 8 },
+      ], { signal });
+
+      const seen = new Set<string>();
+      const items: PlannerMediaItem[] = [];
+      for (const event of events) {
+        if (seen.has(event.id)) continue;
+        seen.add(event.id);
+        const identifier = event.tags.find(([name]) => name === 'd')?.[1] || '';
+        const title = event.tags.find(([name]) => name === 'title')?.[1] ||
+          event.tags.find(([name]) => name === 'summary')?.[1] || '';
+        const image = extractImage(event);
+        const item = buildItem(event, identifier, title, image);
+        if (item) items.push(item);
+      }
+      return items;
+    },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+}

--- a/src/hooks/useSocialPublish.ts
+++ b/src/hooks/useSocialPublish.ts
@@ -1,0 +1,89 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export type SocialPublishPlatform = 'x' | 'facebook' | 'instagram';
+
+export interface SocialBackendStatus {
+  backendOnline: boolean;
+  x: boolean;
+  facebook: boolean;
+  instagram: boolean;
+}
+
+export interface SocialPublishInput {
+  platform: SocialPublishPlatform;
+  text: string;
+  imageUrl?: string;
+  url?: string;
+}
+
+export interface SocialPublishResult {
+  ok: boolean;
+  platform: SocialPublishPlatform;
+  id?: string | null;
+  url?: string | null;
+}
+
+const ENDPOINT = '/api/social-publish';
+
+const OFFLINE_STATUS: SocialBackendStatus = {
+  backendOnline: false,
+  x: false,
+  facebook: false,
+  instagram: false,
+};
+
+/**
+ * Whether the posting backend (/api/social-publish Netlify function) is
+ * reachable and which platforms are configured on it. Never returns secrets —
+ * only booleans. On GitHub Pages (no function runtime) this resolves to
+ * backendOnline:false without throwing.
+ */
+export function useSocialBackendStatus() {
+  return useQuery<SocialBackendStatus>({
+    queryKey: ['social-backend-status'],
+    queryFn: async (): Promise<SocialBackendStatus> => {
+      try {
+        const res = await fetch(ENDPOINT, { signal: AbortSignal.timeout(8000) });
+        if (!res.ok) return OFFLINE_STATUS;
+        const data = await res.json();
+        return {
+          backendOnline: true,
+          x: Boolean(data && data.x),
+          facebook: Boolean(data && data.facebook),
+          instagram: Boolean(data && data.instagram),
+        };
+      } catch {
+        return OFFLINE_STATUS;
+      }
+    },
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
+/**
+ * Post text (and optionally an image) to X / Facebook / Instagram through the
+ * backend. Throws with the server's message on failure so callers can toast it.
+ */
+export function useSocialPublish() {
+  const queryClient = useQueryClient();
+  return useMutation<SocialPublishResult, Error, SocialPublishInput>({
+    mutationFn: async (input) => {
+      const res = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+        signal: AbortSignal.timeout(90000),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error((data && data.error) || `Publish failed (HTTP ${res.status})`);
+      }
+      return data as SocialPublishResult;
+    },
+    onSuccess: () => {
+      // Config may have changed (e.g. first successful post) — refresh badges.
+      queryClient.invalidateQueries({ queryKey: ['social-backend-status'] });
+    },
+  });
+}

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -134,7 +134,7 @@ export default function AdminPanel() {
                 <Link to="/admin/share-scheduler">
                   <Button variant="default" className="bg-purple-600 hover:bg-purple-700">
                     <Clock className="w-4 h-4 mr-2" />
-                    Social Media
+                    Social Media Planner
                   </Button>
                 </Link>
                 <Link to="/admin/app-builder">

--- a/src/pages/ShareScheduler.tsx
+++ b/src/pages/ShareScheduler.tsx
@@ -17,11 +17,14 @@ import { useSocialScheduledPosts, type SocialPlatform, type SocialScheduledPost 
 import { useNostr } from '@nostrify/react';
 import { nip19 } from 'nostr-tools';
 ;
-import { Calendar, Clock, Plus, Trash2, ArrowLeft, Shield, CheckCircle2, AlertCircle, Image as ImageIcon, Link2, Hash, Star, BookOpen, MapPin, Camera, Edit, Loader2, Wand2, Twitter, Instagram, Facebook, Zap, Info, ExternalLink } from 'lucide-react';;
+import { Calendar, Clock, Plus, Trash2, ArrowLeft, Shield, CheckCircle2, AlertCircle, Image as ImageIcon, Link2, Hash, Star, BookOpen, MapPin, Camera, Edit, Loader2, Wand2, Twitter, Instagram, Facebook, Zap, Info, ExternalLink, Copy, Send, PlugZap, WifiOff } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useToast } from '@/hooks/useToast';
 import { formatDistanceToNow, format } from 'date-fns';
 import { TwitterSync } from '@/components/TwitterSync';
+import { PlannerMediaPicker } from '@/components/PlannerMediaPicker';
+import type { PlannerMediaItem } from '@/hooks/usePlannerMedia';
+import { useSocialBackendStatus, useSocialPublish, type SocialPublishPlatform } from '@/hooks/useSocialPublish';
 
 interface ScheduledPost {
   id: string;
@@ -50,6 +53,13 @@ const POST_TYPE_LABELS = {
   trip: 'Trip',
   'stock-media': 'Stock Media',
   custom: 'Custom Post',
+};
+
+const TYPE_BY_PLANNER_CATEGORY: Record<string, ScheduledPost['type']> = {
+  reviews: 'review',
+  stories: 'story',
+  trips: 'trip',
+  stock: 'stock-media',
 };
 
 export default function ShareScheduler() {
@@ -198,6 +208,23 @@ export default function ShareScheduler() {
     } finally {
       setIsFetchingContent(false);
     }
+  };
+
+  const handlePlannerPick = (item: PlannerMediaItem) => {
+    setFormData({
+      ...formData,
+      type: TYPE_BY_PLANNER_CATEGORY[item.category] || 'custom',
+      url: item.url,
+      title: item.title,
+      description: '',
+      imageUrl: item.image,
+      hashtags: item.hashtags.join(', '),
+    });
+    toast({
+      title: 'Media added',
+      description: `"${item.title}" - review the post, then schedule or publish it.`,
+    });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -379,6 +406,9 @@ export default function ShareScheduler() {
             {/* Nostr Tab */}
             <TabsContent value="nostr">
               <div className="grid lg:grid-cols-2 gap-6">
+            <div className="lg:col-span-2">
+              <PlannerMediaPicker onPick={handlePlannerPick} />
+            </div>
             {/* Schedule Form */}
             <div>
               <Card>
@@ -916,6 +946,115 @@ function SocialMediaScheduler({ platform }: SocialMediaSchedulerProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isFetchingContent, setIsFetchingContent] = useState(false);
   
+  const apiPlatform: SocialPublishPlatform = platform === 'twitter' ? 'x' : platform;
+  const connectedKey = apiPlatform === 'x' ? 'x' : apiPlatform;
+  const { data: backendStatus } = useSocialBackendStatus();
+  const publishMutation = useSocialPublish();
+  const [isPosting, setIsPosting] = useState(false);
+
+  const SETUP_STEPS: Record<SocialPublishPlatform, string[]> = {
+    x: [
+      'Create an X developer project (developer.x.com) with Read & Write permissions (free tier allows posting).',
+      'Copy the OAuth 1.0a keys: API Key, API Secret, Access Token, Access Token Secret.',
+      'Add them as Netlify env vars: X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_TOKEN_SECRET.',
+    ],
+    facebook: [
+      'Create a Meta app at developers.facebook.com → add the "Pages" product.',
+      'Get a long-lived Page Access Token with pages_manage_posts (Graph API Explorer → your Page).',
+      'Add env vars: FB_PAGE_ID, FB_PAGE_ACCESS_TOKEN.',
+    ],
+    instagram: [
+      'Make sure the Instagram account is a Business/Professional account linked to your Facebook Page.',
+      'Get the Page Access Token with instagram_basic + instagram_content_publish permissions.',
+      'Add env vars: IG_BUSINESS_ID (your Instagram Business account ID) and FB_PAGE_ACCESS_TOKEN.',
+    ],
+  };
+
+  const composeText = () => {
+    const text = [formData.title, formData.description]
+      .filter(Boolean)
+      .join('\n\n');
+    const hashtagText = formData.hashtags
+      .split(/[,\s]+/)
+      .map((h) => h.trim())
+      .filter(Boolean)
+      .map((h) => (h.startsWith('#') ? h : `#${h}`))
+      .join(' ');
+    const body = [text, hashtagText].filter(Boolean).join('\n\n');
+    return formData.url ? `${body}\n\n${formData.url}` : body;
+  };
+
+  const handlePostNow = async () => {
+    if (!formData.url || !formData.title) {
+      toast({
+        title: 'Missing content',
+        description: 'Pick media or fill in URL and title first',
+        variant: 'destructive',
+      });
+      return;
+    }
+    const text = composeText();
+    if (text.length > platformCharLimits[platform]) {
+      toast({
+        title: 'Too long for ' + platformName,
+        description: `${text.length} / ${platformCharLimits[platform]} characters - shorten the text first`,
+        variant: 'destructive',
+      });
+      return;
+    }
+    setIsPosting(true);
+    try {
+      const result = await publishMutation.mutateAsync({
+        platform: apiPlatform,
+        text,
+        imageUrl: formData.imageUrl || undefined,
+        url: formData.url,
+      });
+      toast({
+        title: `Posted to ${platformName}!`,
+        description: result.url || 'Your post is live.',
+      });
+      setFormData((prev) => ({ ...prev, description: '' }));
+    } catch (err) {
+      toast({
+        title: `Post to ${platformName} failed`,
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsPosting(false);
+    }
+  };
+
+  const handleCopyText = async () => {
+    if (!formData.title) {
+      toast({ title: 'Nothing to copy yet', variant: 'destructive' });
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(composeText());
+      toast({ title: 'Copied!', description: 'Post text is on your clipboard.' });
+    } catch {
+      toast({ title: 'Clipboard unavailable', variant: 'destructive' });
+    }
+  };
+
+  const handlePlannerPick = (item: PlannerMediaItem) => {
+    setFormData({
+      ...formData,
+      type: TYPE_BY_PLANNER_CATEGORY[item.category] || 'custom',
+      url: item.url,
+      title: item.title,
+      description: '',
+      imageUrl: item.image,
+      hashtags: item.hashtags.join(', '),
+    });
+    toast({
+      title: 'Media added',
+      description: `"${item.title}" - ready to post to ${platformName}.`,
+    });
+  };
+
   // xNostr-style sync state
   const [syncConfig, setSyncConfig] = useState({
     autoSync: false,
@@ -1146,8 +1285,125 @@ function SocialMediaScheduler({ platform }: SocialMediaSchedulerProps) {
 
   const currentCharCount = formData.title.length + formData.description.length + formData.hashtags.length + formData.url.length + 10;
 
+  const backendUp = Boolean(backendStatus?.backendOnline);
+  const backendConfigured = Boolean(backendUp && backendStatus?.[connectedKey]);
+
+  const intentUrl =
+    platform === 'twitter'
+      ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(formData.title + (formData.description ? `\n\n${formData.description}` : ''))}&url=${encodeURIComponent(formData.url || '')}&hashtags=${encodeURIComponent((formData.hashtags || '').split(/[,\s]+/).filter(Boolean).map(h => h.replace(/^#/, '')).join(','))}`
+      : platform === 'facebook'
+        ? `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(formData.url || '')}`
+        : 'https://www.instagram.com/';
+
   return (
     <div className="space-y-6">
+      <PlannerMediaPicker onPick={handlePlannerPick} />
+
+      {/* ── Publish to {platformName} ── */}
+      <Card className="border-2" style={{ borderColor: color }} id={`publish-${platform}`}>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="h-12 w-12 rounded-lg flex items-center justify-center" style={{ backgroundColor: `${color}20` }}>
+              <Icon className="w-6 h-6" style={{ color }} />
+            </div>
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                Publish to {platformName}
+                {backendConfigured ? (
+                  <Badge className="bg-green-100 text-green-700">Ready to post</Badge>
+                ) : (
+                  <Badge variant="secondary">Needs setup</Badge>
+                )}
+              </CardTitle>
+              <CardDescription>
+                Send this media straight to {platformName}. Your API keys stay in the
+                server environment - this browser never sees them.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {backendUp ? (
+            backendConfigured ? (
+              <Alert className="bg-green-50 border-green-200">
+                <CheckCircle2 className="h-4 w-4 text-green-600" />
+                <AlertTitle className="text-green-900">Connected</AlertTitle>
+                <AlertDescription className="text-green-800 text-sm">
+                  Posting backend is live and {platformName} credentials are configured. Hit "{'Post now'}" to publish instantly.
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <Alert className="bg-amber-50 border-amber-200">
+                <AlertCircle className="h-4 w-4 text-amber-600" />
+                <AlertTitle className="text-amber-900">Setup needed</AlertTitle>
+                <AlertDescription className="text-amber-800 text-sm">
+                  <div className="space-y-1.5 mt-1">
+                    {SETUP_STEPS[apiPlatform].map((step, i) => (
+                      <div key={i}>• {step}</div>
+                    ))}
+                  </div>
+                  <p className="mt-2 text-xs">After adding the env vars in Netlify, redeploy once - the badge here flips to green.</p>
+                </AlertDescription>
+              </Alert>
+            )
+          ) : (
+            <Alert className="bg-amber-50 border-amber-200">
+              <WifiOff className="h-4 w-4 text-amber-600" />
+              <AlertTitle className="text-amber-900">Posting backend is offline right now</AlertTitle>
+              <AlertDescription className="text-amber-800 text-sm">
+                The live site runs on GitHub Pages, so the /api/social-publish Netlify function is not reachable until the
+                Netlify site for this repo is deployed again (built-in function runtime). Everything below still works -
+                or use the shortcut buttons to open {platformName}'s own composer with this text pre-filled and post in one tap.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              onClick={handlePostNow}
+              disabled={
+                isPosting ||
+                !backendConfigured ||
+                !formData.url ||
+                !formData.title ||
+                (platform === 'instagram' && !formData.imageUrl)
+              }
+              style={{ backgroundColor: color }}
+              className="hover:opacity-90"
+            >
+              {isPosting ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Send className="w-4 h-4 mr-2" />}
+              {isPosting ? 'Posting…' : `Post now to ${platformName}`}
+            </Button>
+            <Button type="button" variant="outline" onClick={handleCopyText} disabled={!formData.title}>
+              <Copy className="w-4 h-4 mr-2" />
+              Copy text
+            </Button>
+            <a
+              href={formData.url ? intentUrl : undefined}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-disabled={!formData.url}
+              className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition ${
+                formData.url
+                  ? 'border-input bg-background hover:bg-accent hover:text-accent-foreground'
+                  : 'pointer-events-none opacity-50'
+              }`}
+            >
+              <ExternalLink className="w-4 h-4" />
+              Open {platformName} composer
+            </a>
+          </div>
+
+          {!backendConfigured && (
+            <div className="text-xs text-muted-foreground pt-1 border-t">
+              💡 Manual flow: <b>Copy text</b> → <b>Open {platformName} composer</b> → paste + attach the image → Post.
+              No app setup needed for that path.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* xNostr-style Sync Card (Full Width) */}
       {(platform === 'twitter' || platform === 'instagram') && (
         <Card className="border-2" style={{ borderColor: color }}>
@@ -1235,14 +1491,11 @@ function SocialMediaScheduler({ platform }: SocialMediaSchedulerProps) {
                 <Button 
                   className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
                   onClick={() => {
-                    toast({
-                      title: 'Coming Soon!',
-                      description: `${platformName} sync integration is under development. Subscribe to our newsletter for updates!`,
-                    });
+                    document.getElementById(`publish-${platform}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
                   }}
                 >
-                  <Icon className="w-4 h-4 mr-2" />
-                  Connect {platformName}
+                  <PlugZap className="w-4 h-4 mr-2" />
+                  Go to Publish
                 </Button>
               </div>
 


### PR DESCRIPTION
Implements the Admin Panel > **Social Media Planner** requested by @BitPopArt. Additive changes to the existing /admin/share-scheduler page.

**What's new**
- **Pick media from the site**: a relay-backed picker (reviews 34879, stories 30023/34235/34236, trips 30025, stock 30402) fills the composer in one click.
- **Nostr**: existing instant scheduler unchanged (works today).
- **X / Facebook / Instagram**: real Post-now flow through new Netlify function netlify/functions/social-publish.mjs (/api/social-publish): X OAuth 1.0a HMAC-SHA1 with chunked media upload + POST /2/tweets; Facebook photo/message via Graph API; Instagram container + media_publish. Credentials live in Netlify env vars only (never in the browser).
- **Per-platform status badge** (Ready / Needs setup with exact env-var steps / Backend offline) + manual fallback (copy text, open platform composer pre-filled).

**Docs**: SOCIAL_MEDIA_PLANNER.md.

Note: the live site runs on GitHub Pages (no function runtime), so the backend badge reads offline until the repo's Netlify project is deployed again; composer-shortcut publishing works regardless. Verified locally: npm run test green (tsc + eslint + vitest + build).